### PR TITLE
chore(playbook): bring base template into compliance with Pesantech E…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost:8000
 
+# CORS — set to specific domains in production (e.g. https://app.yourdomain.com)
+# Pesantech Playbook §11.1: wildcard '*' MUST NOT be used in production
+CORS_ALLOWED_ORIGINS=*
+
 LOG_CHANNEL=stack
 
 # Database Configuration
@@ -51,6 +55,10 @@ PUSHER_APP_CLUSTER=mt1
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+
+# Debugging tools — MUST be false in production (Pesantech Playbook §4.7)
+TELESCOPE_ENABLED=false
+PULSE_ENABLED=false
 
 # Turn this off, if your want to disable demo login filled data.
 DEMO_MODE=false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Pesantech Engineering Playbook §3.3
+# Default owner for all files — requires review from engineering team on every PR
+
+* @pesantechid/engineering
+
+# CI/CD and infrastructure changes require extra attention
+.github/workflows/ @pesantechid/engineering
+Dockerfile* @pesantechid/engineering
+docker-compose* @pesantechid/engineering
+
+# Security-sensitive config files
+config/auth.php @pesantechid/engineering
+config/cors.php @pesantechid/engineering
+config/sanctum.php @pesantechid/engineering
+
+# Playbook and ADRs
+docs/ @pesantechid/engineering

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- Describe what this PR does and why. Link to issue/ticket if applicable. -->
+
+Closes #
+
+---
+
+## Checklist (Pesantech Engineering Playbook §8.3)
+
+### General
+- [ ] Linked issue/ticket referenced above
+- [ ] Branch name follows convention (`feat/`, `fix/`, `chore/`, `refactor/`, `docs/`)
+- [ ] Commit messages follow Conventional Commits format
+
+### Code quality
+- [ ] Tests added or updated for changes made
+- [ ] `composer test` passes locally (Pint + PHPStan level 6 + Pest)
+- [ ] No new PHPStan errors without baseline entry justification
+- [ ] No new Rector suggestions left unaddressed
+
+### Modules (if applicable)
+- [ ] New table names prefixed with module slug (e.g. `crm_clients`)
+- [ ] New migrations are reversible (`down()` implemented) — or marked `FORWARD-ONLY` per §6.7.5
+- [ ] Permissions seeded via `{Module}PermissionSeeder` if new permissions added
+- [ ] Module README updated if public API surface changed
+- [ ] No direct cross-module calls (use events/hooks per §6.3.5)
+
+### Security
+- [ ] No secrets, tokens, or credentials committed
+- [ ] No modifications to `app/`, `bootstrap/`, `config/`, `routes/` core files — or ADR linked if unavoidable
+- [ ] CORS, auth, or session config changes reviewed
+
+### Documentation
+- [ ] CHANGELOG.md updated (Keep-a-Changelog format)
+- [ ] ADR written if this PR introduces an architectural decision (§13.2)
+
+---
+
+## Testing Notes
+
+<!-- How was this tested? What scenarios were covered? -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "php"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Secret scanning
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Secret scanning (gitleaks)
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz" \
+            | tar xz -C /tmp gitleaks
+          /tmp/gitleaks detect --source . --redact --exit-code 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,15 @@ jobs:
       - name: Install Composer Dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
 
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Build Assets
+        run: npm run build
+
       - name: Generate Application Key
         run: php artisan key:generate
 
@@ -108,20 +117,14 @@ jobs:
       - name: Rector dry-run
         run: ./vendor/bin/rector process --dry-run
 
-      - name: Pest (unit + feature tests)
+      - name: Pest (unit + feature + browser tests)
         run: composer pest
 
       - name: Composer audit
         run: composer audit --abandoned=report
 
-      - name: Install NPM Dependencies
-        run: npm ci
-
       - name: NPM lint
         run: npm run lint
-
-      - name: Build Assets
-        run: npm run build
 
       - name: NPM audit
         run: npm audit --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lara Dashboard CI
+name: CI
 
 permissions:
   contents: read
@@ -10,13 +10,13 @@ on:
     branches: [main]
 
 jobs:
-  laravel-tests:
+  quality:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
 
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: testing
@@ -28,9 +28,24 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Secret scanning
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -42,8 +57,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.3"
-          extensions: mbstring, dom, fileinfo, mysql
-          coverage: xdebug
+          extensions: mbstring, dom, fileinfo, mysql, redis, gd, intl, bcmath, zip
+          coverage: pcov
 
       - name: Copy .env
         run: php -r "file_exists('.env') || copy('.env.example', '.env');"
@@ -56,29 +71,15 @@ jobs:
           echo "DB_DATABASE=testing" >> .env
           echo "DB_USERNAME=root" >> .env
           echo "DB_PASSWORD=password" >> .env
+          echo "REDIS_HOST=127.0.0.1" >> .env
+          echo "REDIS_PORT=6379" >> .env
           echo "APP_ENV=testing" >> .env
           echo "SKIP_DB_CHECK_IN_CI=true" >> .env
+          echo "TELESCOPE_ENABLED=false" >> .env
+          echo "PULSE_ENABLED=false" >> .env
 
-      - name: Wait for MySQL to be ready
-        run: |
-          echo "Waiting for MySQL..."
-          until mysqladmin ping -h 127.0.0.1 -u root -ppassword --silent; do
-            sleep 2
-          done
-
-      - name: Install Dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-
-      - name: Install NPM Dependencies
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
-
-      - name: Build Assets
-        run: npm run build
-
-      - name: Install Playwright Browsers
-        run: npx playwright install
+      - name: Install Composer Dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
 
       - name: Generate Application Key
         run: php artisan key:generate
@@ -86,8 +87,40 @@ jobs:
       - name: Set Directory Permissions
         run: chmod -R 777 storage bootstrap/cache
 
-      - name: Run Migrations and Seed
-        run: php artisan migrate:fresh --seed --force
+      - name: Migrate (forward)
+        run: php artisan migrate --force
 
-      - name: Run Tests
-        run: composer run test
+      - name: Migrate rollback test
+        run: |
+          php artisan migrate:rollback --force
+          php artisan migrate --force
+
+      - name: Seed database
+        run: php artisan db:seed --force
+
+      - name: Pint (code style)
+        run: composer pint
+
+      - name: PHPStan (static analysis)
+        run: composer phpstan
+
+      - name: Rector dry-run
+        run: ./vendor/bin/rector process --dry-run
+
+      - name: Pest (unit + feature tests)
+        run: composer pest
+
+      - name: Composer audit
+        run: composer audit --abandoned=report
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: NPM lint
+        run: npm run lint
+
+      - name: Build Assets
+        run: npm run build
+
+      - name: NPM audit
+        run: npm audit --audit-level=high

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,86 @@
+# Pesantech Framework — Production Dockerfile
+# Based on FrankenPHP (Caddy + PHP in one binary) per Pesantech Playbook §4.5, §10.3
+# Build: docker build -f Dockerfile.production -t pesantech-app:latest .
+
+FROM dunglas/frankenphp:1-php8.3-alpine AS base
+
+LABEL maintainer="Pesantech Engineering <engineering@pesantech.id>"
+
+# Install system dependencies
+RUN apk add --no-cache \
+    libpng-dev \
+    libjpeg-turbo-dev \
+    libwebp-dev \
+    libzip-dev \
+    icu-dev \
+    oniguruma-dev \
+    && docker-php-ext-configure gd --with-jpeg --with-webp \
+    && docker-php-ext-install \
+        pdo_mysql \
+        mbstring \
+        gd \
+        zip \
+        intl \
+        bcmath \
+        opcache \
+        pcntl \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && rm -rf /var/cache/apk/*
+
+# PHP production config
+COPY docker/php/php-production.ini /usr/local/etc/php/conf.d/99-production.ini
+
+WORKDIR /app
+
+# --- Composer dependencies ---
+FROM base AS vendor
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-scripts \
+    --no-autoloader \
+    --no-interaction \
+    --prefer-dist
+
+COPY . .
+RUN composer dump-autoload --optimize --no-dev
+
+# --- Node build ---
+FROM node:22-alpine AS assets
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+RUN npm run build
+
+# --- Final image ---
+FROM base AS production
+
+WORKDIR /app
+
+# Copy app
+COPY --chown=www-data:www-data . .
+COPY --chown=www-data:www-data --from=vendor /app/vendor ./vendor
+COPY --chown=www-data:www-data --from=assets /app/public/build ./public/build
+
+# Storage & bootstrap writable
+RUN mkdir -p storage/logs storage/framework/{cache,sessions,views} bootstrap/cache \
+    && chmod -R 775 storage bootstrap/cache \
+    && chown -R www-data:www-data storage bootstrap/cache
+
+# Caddyfile for FrankenPHP
+COPY docker/caddy/Caddyfile /etc/caddy/Caddyfile
+
+# Artisan optimize on startup
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 80 443
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/composer.lock
+++ b/composer.lock
@@ -262,16 +262,16 @@
         },
         {
             "name": "dedoc/scramble",
-            "version": "v0.13.16",
+            "version": "v0.13.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dedoc/scramble.git",
-                "reference": "43a5dd62b6a5d7d6fd0125092985d78ae22f0ffe"
+                "reference": "b54b0c43bdebaa01f66cc3dfdd8f91e19b12da96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dedoc/scramble/zipball/43a5dd62b6a5d7d6fd0125092985d78ae22f0ffe",
-                "reference": "43a5dd62b6a5d7d6fd0125092985d78ae22f0ffe",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/b54b0c43bdebaa01f66cc3dfdd8f91e19b12da96",
+                "reference": "b54b0c43bdebaa01f66cc3dfdd8f91e19b12da96",
                 "shasum": ""
             },
             "require": {
@@ -330,7 +330,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dedoc/scramble/issues",
-                "source": "https://github.com/dedoc/scramble/tree/v0.13.16"
+                "source": "https://github.com/dedoc/scramble/tree/v0.13.22"
             },
             "funding": [
                 {
@@ -338,7 +338,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-17T21:42:41+00:00"
+            "time": "2026-04-27T20:30:51+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -4042,16 +4042,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.51",
+            "version": "3.0.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
                 "shasum": ""
             },
             "require": {
@@ -4132,7 +4132,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
             },
             "funding": [
                 {
@@ -4148,7 +4148,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T01:33:53+00:00"
+            "time": "2026-04-27T07:02:15+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/config/cors.php
+++ b/config/cors.php
@@ -13,13 +13,22 @@ return [
     |
     | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
     |
+    | SECURITY NOTE (Pesantech Playbook §11.1):
+    | CORS_ALLOWED_ORIGINS must be set to specific domains in production.
+    | Example: CORS_ALLOWED_ORIGINS=https://app.yourdomain.com,https://api.yourdomain.com
+    | Wildcard '*' is only acceptable for fully public, read-only APIs.
+    |
     */
 
     'paths' => ['api/*'],
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    // Set CORS_ALLOWED_ORIGINS in .env — comma-separated. Defaults to '*' for local dev only.
+    'allowed_origins' => array_filter(
+        explode(',', env('CORS_ALLOWED_ORIGINS', '*')),
+        fn ($origin) => $origin !== ''
+    ),
 
     'allowed_origins_patterns' => [],
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,83 @@
+# Pesantech Framework — Local Development Stack
+# Pesantech Engineering Playbook §4.5, §4.7
+#
+# Usage:
+#   docker compose -f docker-compose.dev.yml up -d
+#   docker compose -f docker-compose.dev.yml down
+#
+# Access:
+#   App:      http://localhost:8000  (php artisan serve / composer dev)
+#   MySQL:    localhost:3306         (root / secret)
+#   Redis:    localhost:6379
+#   Mailpit:  http://localhost:8025  (catch-all SMTP for dev email)
+#   MinIO:    http://localhost:9001  (S3-compatible storage console)
+
+services:
+  mysql:
+    image: mysql:8.4
+    container_name: pesantech_mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: pesantech_local
+      MYSQL_USER: pesantech
+      MYSQL_PASSWORD: secret
+    ports:
+      - "3306:3306"
+    volumes:
+      - pesantech_mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-psecret"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: pesantech_redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - pesantech_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: pesantech_mailpit
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP — set MAIL_HOST=localhost MAIL_PORT=1025 in .env
+      - "8025:8025"   # Web UI — http://localhost:8025
+    environment:
+      MP_MAX_MESSAGES: 500
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+
+  minio:
+    image: minio/minio:latest
+    container_name: pesantech_minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"   # S3 API — set AWS_ENDPOINT=http://localhost:9000 in .env
+      - "9001:9001"   # Console — http://localhost:9001 (minioadmin / minioadmin)
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - pesantech_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  pesantech_mysql_data:
+  pesantech_redis_data:
+  pesantech_minio_data:

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,44 @@
+{
+    # FrankenPHP config
+    frankenphp
+
+    # Disable admin endpoint in production
+    admin off
+}
+
+{$APP_URL:localhost} {
+    root * /app/public
+
+    # Serve PHP via FrankenPHP
+    php_server
+
+    # Compress responses
+    encode zstd br gzip
+
+    # Security headers
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options nosniff
+        X-Frame-Options SAMEORIGIN
+        Referrer-Policy strict-origin-when-cross-origin
+        Permissions-Policy "geolocation=(), microphone=(), camera=()"
+        -Server
+    }
+
+    # Health check endpoint (§12.2)
+    handle /health {
+        respond "OK" 200
+    }
+
+    # Static assets — long cache
+    @static {
+        path /build/* /css/* /js/* /images/* /fonts/* /favicon.ico
+    }
+    header @static Cache-Control "public, max-age=31536000, immutable"
+
+    log {
+        output stderr
+        format json
+        level INFO
+    }
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+echo "==> Pesantech: running startup optimizations..."
+
+# Cache config, routes, views for production (Playbook §10.4)
+php artisan optimize
+
+# Run pending migrations (if any) — uses DB backup hook in CD pipeline before this
+php artisan migrate --force
+
+echo "==> Starting FrankenPHP..."
+exec frankenphp run --config /etc/caddy/Caddyfile "$@"

--- a/docker/php/php-production.ini
+++ b/docker/php/php-production.ini
@@ -1,0 +1,24 @@
+; Pesantech production PHP settings
+
+; OPcache (always on in prod — Playbook §10.4)
+opcache.enable=1
+opcache.enable_cli=0
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=20000
+opcache.revalidate_freq=0
+opcache.validate_timestamps=0
+opcache.save_comments=1
+opcache.fast_shutdown=1
+
+; Security
+expose_php=Off
+display_errors=Off
+log_errors=On
+error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT
+
+; Performance
+memory_limit=256M
+max_execution_time=60
+upload_max_filesize=20M
+post_max_size=20M

--- a/docs/adr/0001-adopt-pesantech-engineering-playbook.md
+++ b/docs/adr/0001-adopt-pesantech-engineering-playbook.md
@@ -1,0 +1,53 @@
+# ADR 0001 — Adopt Pesantech Engineering Playbook v1.1
+
+| Field    | Value |
+|----------|-------|
+| Status   | Accepted |
+| Date     | 2026-05-09 |
+| Deciders | @pesantechid/engineering |
+
+## Context
+
+Pesantech.id is building multiple Laravel-based products (agency tools, internal systems, SaaS candidates). Without a shared standard, each project reinvents auth, RBAC, CI/CD, module structure, and security configuration — costing weeks per project and creating inconsistency.
+
+A playbook that codifies a single base + composable modules strategy is needed to:
+- Ship new projects in <1 day instead of 1–2 weeks.
+- Ensure security patches propagate cleanly across all projects.
+- Treat every business capability as a reusable, versionable module.
+
+## Decision
+
+Adopt **Pesantech Engineering Playbook v1.1** (2026-05-07) as the internal engineering standard for all Pesantech.id products.
+
+The playbook is stored at `docs/playbook.md` in this repository and will be distributed to all project repositories via the base template.
+
+Key decisions codified by the playbook:
+1. Base template (`pesantech-framework`) is immutable in projects — all customization lives in `Modules/`.
+2. Upstream sync uses tags only (Tier 1), never branches.
+3. PHPStan level 6+ enforced in CI.
+4. All modules must have table prefix, PermissionSeeder, reversible migrations, and Pest tests.
+5. AI agents (Claude Code, Cursor) must follow §16 task specification standard.
+
+## Consequences
+
+**Positive:**
+- Consistent engineering standards across all projects.
+- AI agents have explicit, testable constraints — fewer hallucinations and scope violations.
+- Security patches and upstream improvements propagate predictably.
+
+**Negative:**
+- Some upfront investment required to bring existing repos into compliance.
+- Developers must learn and follow the standard.
+
+**Risks & mitigations:**
+- Playbook may become stale: quarterly review cadence (next review: 2026-08-07) mitigates this.
+
+## Alternatives considered
+
+- **No playbook (ad-hoc):** Rejected — already experiencing duplication and inconsistency across projects.
+- **Adopt a public standard (e.g. Spatie guidelines):** Rejected — does not cover Pesantech's specific multi-project module strategy and AI-assisted development workflow.
+
+## References
+
+- `docs/playbook.md` — full document
+- https://adr.github.io — ADR pattern

--- a/docs/adr/0002-base-version-pinned.md
+++ b/docs/adr/0002-base-version-pinned.md
@@ -1,0 +1,64 @@
+# ADR 0002 — Base Version Pinned: pesantech-framework v1.0.0 (laradashboard v1.1.3)
+
+| Field    | Value |
+|----------|-------|
+| Status   | Accepted |
+| Date     | 2026-05-09 |
+| Deciders | @pesantechid/engineering |
+
+## Context
+
+Per Pesantech Engineering Playbook §4.4 and §5.5, every project must record the base template version it was bootstrapped from, including the upstream laradashboard version it tracks.
+
+This ADR records the initial state of `pesantech-framework` as the Pesantech L1 base template.
+
+## Decision
+
+The Pesantech base template (`pesantech-framework`) is formally declared at:
+
+- **Pesantech base version:** `v1.0.0+laradashboard-1.1.3`
+- **Upstream laradashboard tag:** `v1.1.3` (verified via `git describe`: HEAD is 1 commit above `v1.1.3`)
+- **Upstream remote:** `https://github.com/laradashboard/laradashboard.git`
+- **PHP:** 8.3 / 8.4
+- **Laravel:** 13.x
+- **Livewire:** 4.x
+- **nwidart/laravel-modules:** 13.x
+
+### Sync strategy
+
+Upstream sync follows **Tier 1 (tag-based)** per Playbook §4.3:
+- Monthly cadence or on security advisory.
+- MUST merge upstream tags, never `upstream/main`.
+- Playbook §4.3.3 sync procedure MUST be followed.
+
+### Version tagging convention
+
+```
+v{MAJOR}.{MINOR}.{PATCH}+laradashboard-{UPSTREAM_VERSION}
+```
+
+Next tag to be created after this compliance PR merges:
+```
+git tag -a v1.0.0+laradashboard-1.1.3 -m "Initial Pesantech base — synced from laradashboard v1.1.3"
+```
+
+## Consequences
+
+**Positive:**
+- Clear audit trail of which upstream version each project is based on.
+- Security advisories can be mapped to exact CVE-affected version range.
+- Rollback path is unambiguous.
+
+**Negative:**
+- Tagging discipline must be maintained on every sync — automated reminder needed (quarterly calendar item).
+
+## Alternatives considered
+
+- **Track upstream branch instead of tag:** Rejected — branches are mutable, non-reproducible. See Playbook §4.3.1.
+- **No versioning on base:** Rejected — projects cannot know when to sync or what changed.
+
+## References
+
+- Playbook §4.3 — Upstream sync procedure
+- Playbook §4.4 — Base versioning scheme
+- Playbook §5.5 — Post-bootstrap day-1 checklist (ADR-0002 requirement)

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -1,0 +1,1918 @@
+# Pesantech Engineering Playbook
+## Reusable Base + Multi-Project Module Strategy
+
+| Field | Value |
+|---|---|
+| Document type | Engineering Playbook (Internal Standard) |
+| Version | 1.1 |
+| Status | Approved for execution |
+| Owner | Pesantech.id Engineering |
+| Audience | Developer team, AI implementation agents, future hires, contractors |
+| Last reviewed | 2026-05-07 |
+| Next review | Quarterly |
+| Supersedes | v1.0 (2026-05-06) |
+| Changelog from v1.0 | §4 rewritten (tag-based sync). New: §6.7 module versioning & migration. New: §6.8 deprecation policy. New: §11.4 secrets rotation. New: §11.8 email deliverability. New: §12.6 disaster recovery. New: §15 feature flags. New: §16 AI-assisted implementation. |
+
+---
+
+## Document Conventions
+
+| Marker | Meaning |
+|---|---|
+| **MUST** / **MUST NOT** | Non-negotiable. Violation = blocker for merge. |
+| **SHOULD** / **SHOULD NOT** | Strongly recommended. Deviations require ADR. |
+| **MAY** | Optional. Use judgment. |
+| **ADR** | Architecture Decision Record (see §13) |
+| **PR** | Pull Request |
+| **AI agent** | Coding agent (Claude Code, Cursor, etc.) implementing tasks given by maintainers |
+
+This document is written to be **operationally precise** — readable both by humans and by AI agents executing tasks. Specifications use imperative, testable language. Examples are concrete.
+
+---
+
+## Table of Contents
+
+1. [Strategic Intent](#1-strategic-intent)
+2. [Reference Architecture](#2-reference-architecture)
+3. [Repository Topology](#3-repository-topology)
+4. [Base Repository Operating Model](#4-base-repository-operating-model)
+5. [Project Bootstrap Procedure](#5-project-bootstrap-procedure)
+6. [Module Engineering Standard](#6-module-engineering-standard)
+7. [Module Sharing & Distribution](#7-module-sharing--distribution)
+8. [Branching, Tagging & Release Engineering](#8-branching-tagging--release-engineering)
+9. [Quality Gates & CI/CD](#9-quality-gates--cicd)
+10. [Performance Engineering](#10-performance-engineering)
+11. [Security Baseline](#11-security-baseline)
+12. [Observability, Operations & Disaster Recovery](#12-observability-operations--disaster-recovery)
+13. [Architecture Decision Records (ADR)](#13-architecture-decision-records-adr)
+14. [Glossary & Appendices](#14-glossary--appendices)
+15. [Feature Flags & Progressive Delivery](#15-feature-flags--progressive-delivery)
+16. [AI-Assisted Implementation Standards](#16-ai-assisted-implementation-standards)
+
+---
+
+## 1. Strategic Intent
+
+### 1.1 Why this playbook exists
+
+Pesantech.id delivers Laravel-based products: agency tools, internal systems, eventually SaaS. Without standardization, each project re-invents auth, RBAC, settings, media library, email, audit log, CI/CD — costing weeks per project.
+
+This playbook codifies a **single base + composable modules** strategy that:
+
+- Ships a battle-tested foundation in <1 day instead of 1–2 weeks per project.
+- Keeps the base **immutable** in projects so security patches propagate cleanly.
+- Treats every business capability as a **module** that can be reused, shared, sold.
+- Enables eventual graduation to **commercial/SaaS** without re-architecture.
+
+### 1.2 Non-negotiable principles (the "constitution")
+
+1. **Base is immutable in projects.** Projects **MUST NOT** modify `app/`, `bootstrap/`, `config/` (except files they add), `routes/` core files, or `database/migrations/` core files of the base. All customization lives in `Modules/*`.
+2. **One change, one module.** A new business capability is a new module. **MUST NOT** sprawl across the base.
+3. **Versioned, never copied.** Once a module is reused across ≥2 projects, it **MUST** be extracted to a versioned package.
+4. **Reproducible builds.** Any project **MUST** be reproducible from a clean `git clone` + `composer install` + documented commands. Pinned versions, not "latest."
+5. **Quality gates pass before merge.** Lint + static analysis + tests **MUST** be green. No exceptions.
+6. **Document the why, not the what.** ADRs capture decisions. Code comments explain rationale, not mechanics.
+7. **Track upstream releases, not branches.** Production-bound code **MUST** track upstream tags. Branch tracking is reserved for experimentation. (See §4 for full rationale and procedure.)
+
+These seven points are the constitution. Every other rule derives from them.
+
+### 1.3 Out of scope for this playbook
+
+- Product-specific requirements → individual product PRDs.
+- Hiring & team management.
+- Sales/commercial strategy for productized modules.
+
+---
+
+## 2. Reference Architecture
+
+### 2.1 Layered model
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ L0 — Upstream                                               │
+│   laradashboard/laradashboard (open source, MIT)            │
+│   PHP 8.3+, Laravel 13, Livewire 4, Tailwind 4, Modules 13  │
+│   We track tags. We do not modify.                          │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ controlled, audited tag sync
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│ L1 — Base Template (Pesantech)                              │
+│   pesantechid/pesantech-framework                           │
+│   Configured as GitHub Template Repository.                 │
+│   Hardening: CI templates, Docker, security defaults,       │
+│   org-mandated tooling. Tagged releases.                    │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ "Use this template" → fresh repo
+       ┌───────────────────┼───────────────────┐
+       ▼                   ▼                   ▼
+┌────────────┐      ┌────────────┐      ┌────────────┐
+│ L2a Project│      │ L2b Project│      │ L2c Project│
+│  Kendali   │      │   ...      │      │   ...      │
+│ Modules/   │      │ Modules/   │      │ Modules/   │
+└─────┬──────┘      └─────┬──────┘      └─────┬──────┘
+      └─────────┬─────────┴─────────┬─────────┘
+                ▼                   ▼
+       ┌─────────────────┐  ┌─────────────────┐
+       │ L3 Module Pkgs  │  │ L4 Infra        │
+       │ (Composer VCS / │  │ (Docker, K8s,   │
+       │  Private Pkgist)│  │  CI templates,  │
+       │                 │  │  IaC)           │
+       └─────────────────┘  └─────────────────┘
+```
+
+### 2.2 Layer responsibilities
+
+| Layer | Repo example | Mutable by us? | Purpose |
+|---|---|---|---|
+| L0 Upstream | `laradashboard/laradashboard` | No (read only) | Source of truth for foundation |
+| L1 Base Template | `pesantechid/pesantech-framework` | Yes, conservatively | Pesantech-hardened starting point |
+| L2 Project | `pesantechid/kendali`, etc. | Yes, freely | Real product code |
+| L3 Module Packages | `pesantechid/module-*` | Yes, semver-controlled | Reusable business capabilities |
+| L4 Infra | `pesantechid/infra-tooling` | Yes | Deployment, CI, IaC, runtime configs |
+
+### 2.3 Data flow rules
+
+- **L0 → L1 sync:** scheduled, **tag-based only**, reviewed (see §4.3).
+- **L1 → L2 instantiation:** once per project, via "Use this template".
+- **L1 → L2 sync (post-instantiation):** on-demand, when L1 receives security patch or significant base improvement; tag-based.
+- **L2 ↔ L3:** standard Composer dependency; SemVer enforced (see §7.4).
+- **L4 → L1, L2:** distributed via reusable GitHub Actions workflows + shared Docker base images.
+
+---
+
+## 3. Repository Topology
+
+### 3.1 Naming conventions
+
+| Repo type | Naming | Example |
+|---|---|---|
+| Base template | `pesantechid/pesantech-framework` | (current) |
+| Product (project) | `pesantechid/{product}` | `pesantechid/kendali` |
+| Shared module package | `pesantechid/module-{name}` | `pesantechid/module-vault` |
+| Infra tooling | `pesantechid/infra-{purpose}` | `pesantechid/infra-tooling` |
+| Documentation site | `pesantechid/{product}-docs` | `pesantechid/kendali-docs` |
+
+### 3.2 Visibility & access
+
+| Repo type | Default visibility | Rationale |
+|---|---|---|
+| Base template | Public OR Private | Optional public allows community contribution back |
+| Product | **Private** | Business logic, client-specific data |
+| Module package | Private (default) | Until explicitly productized |
+| Infra | Private | Contains deploy secrets templates |
+
+Branch protection rules **MUST** be enabled on `main` for all repos.
+
+### 3.3 Repo metadata requirements
+
+Every repo **MUST** contain:
+
+- `README.md` — purpose, setup, run commands, links to docs.
+- `LICENSE` — explicit license (MIT for open, Proprietary for private).
+- `CHANGELOG.md` — Keep-a-Changelog format.
+- `CODEOWNERS` — for PR review routing.
+- `.github/PULL_REQUEST_TEMPLATE.md` — checklist enforcing this playbook.
+- `.github/dependabot.yml` — automated dependency updates.
+- `SECURITY.md` — vulnerability disclosure process.
+- `docs/adr/` — Architecture Decision Records.
+
+---
+
+## 4. Base Repository Operating Model
+
+### 4.1 Setup as GitHub Template (one-time)
+
+```
+Settings → General → "Template repository" → ☑ enable
+```
+
+Consumable via:
+
+```bash
+gh repo create pesantechid/PROJECT_NAME \
+  --template pesantechid/pesantech-framework \
+  --private \
+  --description "..."
+```
+
+### 4.2 Upstream remote configuration (one-time)
+
+```bash
+cd pesantech-framework
+git remote add upstream https://github.com/laradashboard/laradashboard.git
+git fetch upstream --tags
+git remote -v   # verify
+```
+
+### 4.3 Upstream sync procedure (tag-based, MANDATORY)
+
+**This section was rewritten in v1.1 to enforce tag-based sync.** Production code **MUST NOT** track upstream `main`. Rationale and tier model below.
+
+#### 4.3.1 Why tags, not branches
+
+Upstream Lara Dashboard uses release-branch workflow: features land in `feat/*` branches → tested in `release/v*.*.*` branches → merged to `main` → tagged. Their `main` is updated **only when a release is cut**. This means:
+
+- Tags = explicit declaration "this is ready" by maintainers.
+- Tags = reproducible (a tag is immutable; a branch HEAD changes).
+- Tags = audit-trail for security advisories ("CVE affects ≤v1.1.2 → upgrade to v1.1.3").
+- Tags = clean rollback path.
+
+#### 4.3.2 Three-tier sync strategy
+
+| Tier | Source | When to use | Production-allowed? |
+|---|---|---|---|
+| **1 — Tag** (default) | `upstream/v1.X.Y` tag | All routine syncs | ✅ Yes |
+| **2 — Release branch** | `upstream/release/v1.X.0` branch | Critical fix merged but not yet tagged; pre-validation of upcoming tag in staging | ⚠️ Staging only, with ADR |
+| **3 — Main branch** | `upstream/main` | Experimentation, contributing back, exploratory dev | ❌ Never |
+
+#### 4.3.3 Standard sync procedure (Tier 1)
+
+**Frequency:** monthly OR on security advisory.
+
+```bash
+# 1. Start clean
+git checkout main && git pull
+git checkout -b chore/upstream-sync-$(date +%Y%m%d)
+
+# 2. Fetch upstream tags
+git fetch upstream --tags
+
+# 3. Identify target tag (review CHANGELOG before deciding)
+git tag -l 'upstream-*' | tail -5   # see what we already merged
+git tag -l 'v*' --sort=-v:refname --merged upstream/main | head -5
+# Pick the latest stable tag, e.g. v1.1.3
+
+# 4. Review what changed (MANDATORY — do not skip)
+TARGET=v1.1.3
+PREV=$(git describe --tags --abbrev=0 HEAD)
+git log --oneline ${PREV}..${TARGET}
+git diff ${PREV}..${TARGET} --stat
+
+# 5. Merge the tag (not the branch)
+git merge ${TARGET} --no-ff -m "chore(upstream): sync to laradashboard ${TARGET}"
+
+# 6. Resolve conflicts (should be minimal — see §4.5)
+# 7. Run quality gates LOCALLY before push
+composer install && composer test
+
+# 8. Push and open PR
+git push origin chore/upstream-sync-$(date +%Y%m%d)
+gh pr create --title "chore(upstream): sync to laradashboard ${TARGET}" \
+  --body "Synced from upstream tag: ${TARGET}
+  
+  Upstream changelog excerpts:
+  [paste relevant items from upstream CHANGELOG.md]
+  
+  Files changed: $(git diff --name-only ${PREV}..HEAD | wc -l)
+  Tests: green locally"
+
+# 9. After PR merge, tag the base
+git checkout main && git pull
+git tag -a v1.0.1+laradashboard-1.1.3 -m "Sync with upstream v1.1.3"
+git push origin --tags
+```
+
+#### 4.3.4 Emergency sync procedure (Tier 2 — release branch)
+
+**Use only when:** an upstream fix exists in `release/v*.*.*` but no tag has been cut, AND the fix is critical (security advisory or production bug).
+
+**MUST** include an ADR justifying the deviation. Template:
+
+```
+ADR — Tier 2 sync deviation
+Date: YYYY-MM-DD
+Reason: CVE-XXXX-YYYY in laradashboard <v1.1.4
+Source: upstream/release/v1.1.4 branch at commit abc1234
+Target audience: staging only; production sync awaits official tag
+Plan: re-sync to v1.1.4 tag when published (within 7 days expected)
+```
+
+Procedure:
+
+```bash
+git fetch upstream
+COMMIT=abc1234   # specific commit, not branch HEAD
+git merge ${COMMIT} --no-ff -m "chore(upstream): emergency sync to commit ${COMMIT}"
+# Tag with explicit deviation marker
+git tag -a v1.0.1+laradashboard-pre1.1.4-emergency -m "Emergency sync; replace with v1.1.4 tag when available"
+```
+
+After upstream cuts the tag, **MUST** re-sync to the tag and remove the emergency tag.
+
+#### 4.3.5 Forbidden practices
+
+- ❌ `git merge upstream/main` — bans Tier 3 in production code paths.
+- ❌ Cherry-picking individual commits from upstream into base. Use tags or, if absolutely necessary, an ADR + emergency procedure.
+- ❌ Skipping CHANGELOG review.
+- ❌ Skipping local test run before push.
+
+#### 4.3.6 What happens if upstream goes dormant
+
+Upstream Lara Dashboard could pause development, pivot, or delete the repo. Mitigations:
+
+- Pesantech base repo contains a **complete copy** of the upstream code at every synced tag — Anda tidak bergantung pada upstream availability.
+- If upstream dormant >6 months, document this in an ADR and decide: (a) self-maintain the base (effectively forking permanently), (b) migrate to alternative upstream, or (c) freeze base version.
+
+### 4.4 Base versioning scheme
+
+L1 base versions follow SemVer with build metadata pointing to upstream:
+
+```
+v{MAJOR}.{MINOR}.{PATCH}+laradashboard-{UPSTREAM_VERSION}
+```
+
+Examples:
+- `v1.0.0+laradashboard-1.1.3` — first stable Pesantech base, synced from upstream v1.1.3
+- `v1.1.0+laradashboard-1.2.0` — minor base improvements + upstream sync
+
+**MAJOR** bump when: breaking changes to org-mandated tooling, MUST/SHOULD policies that affect existing projects.
+**MINOR** bump when: new tooling added, upstream sync, additive policy changes.
+**PATCH** bump when: bug fixes in CI templates, Docker, or org configs.
+
+### 4.5 What L1 base **MAY** add
+
+- `Dockerfile.production` (FrankenPHP-based)
+- `docker-compose.dev.yml`
+- `.github/workflows/*` (reusable workflow templates)
+- `.github/CODEOWNERS`
+- `.editorconfig` overrides
+- Pesantech-mandated quality config (e.g., stricter `phpstan.neon` ruleset)
+- `docs/adr/` folder with org-wide ADRs
+- Custom `.env.example` defaults aligned to Pesantech standards
+- This playbook itself, at `docs/playbook.md`
+
+### 4.6 What L1 base **MUST NOT** add
+
+- Business logic of any specific product.
+- Branding of any product (logos, names beyond "Pesantech Framework").
+- Hardcoded credentials, even fake ones beyond what upstream ships.
+- Third-party integration tokens.
+- Modifications to `app/`, `bootstrap/`, `config/` (core upstream files) beyond what's strictly required for org tooling integration.
+
+### 4.7 Base hardening checklist (one-time)
+
+Apply to base before announcing it as production-ready:
+
+- [ ] `.env.example` contains `TELESCOPE_ENABLED=false`, `PULSE_ENABLED=false` for production safety.
+- [ ] `config/telescope.php` and `config/pulse.php` confirmed env-conditional.
+- [ ] `Dockerfile.production` based on `dunglas/frankenphp` with hardened entrypoint.
+- [ ] CI workflow runs Pint, PHPStan (level 6+), Pest, Rector dry-run.
+- [ ] Dependabot configured for `composer` and `npm`.
+- [ ] Pre-commit hook (Husky) enforces commit convention (already present in upstream).
+- [ ] `docker-compose.dev.yml` with mysql, redis, mailpit, minio.
+- [ ] `SECURITY.md` with disclosure email.
+- [ ] `CONTRIBUTING.md` linking to this playbook.
+- [ ] First sync from upstream tag completed.
+- [ ] Base tagged `v1.0.0+laradashboard-{X.Y.Z}`.
+
+---
+
+## 5. Project Bootstrap Procedure
+
+### 5.1 Pre-flight checklist (project-level)
+
+Before bootstrap, the project lead **MUST** confirm:
+
+- [ ] Project name approved (legal, trademark cleared if going commercial).
+- [ ] Domain(s) registered.
+- [ ] Repo naming follows §3.1.
+- [ ] Initial PRD or scope document exists.
+- [ ] Hosting/deploy target identified (VPS/K8s/etc.).
+- [ ] Database technology chosen (MySQL is default; deviation requires ADR).
+- [ ] Base version pinned (e.g., "this project starts from `pesantech-framework@v1.0.0`").
+
+### 5.2 Bootstrap commands
+
+```bash
+# 1. Create from template
+gh repo create pesantechid/PROJECT \
+  --template pesantechid/pesantech-framework \
+  --private \
+  --description "PROJECT_DESCRIPTION"
+
+# 2. Clone
+git clone git@github.com:pesantechid/PROJECT.git
+cd PROJECT
+
+# 3. Add base remote for future syncs (tag-based, per §5.6)
+git remote add base https://github.com/pesantechid/pesantech-framework.git
+git fetch base --tags
+
+# 4. Verify base version (record in ADR-0002)
+git describe --tags --contains $(git rev-parse HEAD) || \
+  echo "Note: template-instantiated repos lose tag context. Base version was: [check template at time of bootstrap]"
+
+# 5. Configure environment
+cp .env.example .env
+# Edit .env
+
+# 6. Install dependencies
+composer install
+npm install
+
+# 7. Application key
+php artisan key:generate
+
+# 8. Database
+php artisan migrate:fresh --seed
+php artisan module:seed
+
+# 9. Verify
+composer test
+composer dev
+```
+
+### 5.3 Project identity customization
+
+The following **MUST** be updated:
+
+| File | Change |
+|---|---|
+| `.env`, `.env.example` | `APP_NAME`, `APP_URL`, defaults |
+| `composer.json` | `name`, `description` |
+| `package.json` | `name`, `version` (start `0.1.0`) |
+| `README.md` | Project README replacing template README |
+| `public/favicon.ico`, `public/logo.svg` | Branded assets |
+
+**Visual branding (logo, colors, site name displayed in UI) MUST go through the Settings panel** in the running application. Editing Blade templates for branding is forbidden — it creates conflicts on base sync.
+
+### 5.4 First commit conventions
+
+```bash
+git add -A
+git commit -m "chore: bootstrap from pesantech-framework template
+
+Project: PROJECT_NAME
+Template: pesantech-framework@vX.Y.Z+laradashboard-A.B.C
+Domain: PROJECT.example.com
+"
+git tag -a v0.0.1 -m "Initial bootstrap"
+git push origin main --tags
+```
+
+### 5.5 Post-bootstrap day-1 checklist
+
+- [ ] CI pipeline runs and passes on first push.
+- [ ] Branch protection on `main` enabled (require PR + 1 review + green CI).
+- [ ] Secrets configured in GitHub Actions (see §11.3).
+- [ ] Staging environment provisioned and reachable.
+- [ ] First module scaffolded as smoke test (e.g., `php artisan module:make Smoke`).
+- [ ] First ADRs written:
+  - ADR-0001 — Adopt Pesantech Engineering Playbook v1.1
+  - ADR-0002 — Base version pinned (record `pesantech-framework@vX.Y.Z`)
+  - ADR-0003 — Database technology chosen
+  - ADR-0004 — Initial runtime (PHP-FPM vs Octane)
+  - ADR-0005 — Multi-tenancy strategy
+  - ADR-0006 — Module taxonomy for this project
+  - ADR-0007 — Upstream sync strategy (per §4.3)
+
+### 5.6 Project sync from base (post-instantiation)
+
+Once a project is instantiated, future base updates flow via the `base` remote:
+
+```bash
+cd PROJECT
+git fetch base --tags
+git checkout -b chore/sync-base-vX.Y.Z
+
+# Pick target tag from base
+TARGET=v1.1.0+laradashboard-1.2.0
+git merge ${TARGET} --no-ff
+# Resolve conflicts (should be minimal if §1.2 principle 1 is honored)
+
+composer install && composer test
+git push origin chore/sync-base-vX.Y.Z
+gh pr create --title "chore(base): sync to ${TARGET}"
+```
+
+**Frequency:** monthly OR on security advisory from base.
+
+---
+
+## 6. Module Engineering Standard
+
+### 6.1 Module taxonomy
+
+| Category | Definition | Example | Reuse expectation |
+|---|---|---|---|
+| **Core extension** | Adds to base capabilities | `Modules/AuditPlus` | High — extraction candidate |
+| **Domain (business)** | Implements business capability | `Modules/Crm` | Medium — extract when proven |
+| **Integration** | Wraps third-party API | `Modules/IntegrationsCloudflare` | Per-vendor reuse |
+| **Project-specific** | Logic only for one product | `Modules/KendaliReports` | None — never extract |
+
+Naming **MUST** reflect category:
+- Domain: single noun, StudlyCase: `Crm`, `Billing`, `Reports`
+- Integration: `Integrations{Vendor}`: `IntegrationsCloudflare`
+- Project-specific: `{ProjectAcronym}{Capability}`: `KendaliReports`
+
+### 6.2 Module structure (mandatory)
+
+```
+modules/{ModuleName}/
+├── Config/
+│   └── config.php
+├── Console/Commands/
+├── Database/
+│   ├── factories/
+│   ├── migrations/
+│   └── seeders/
+│       ├── {Module}DatabaseSeeder.php   # MUST exist
+│       └── {Module}PermissionSeeder.php # MUST exist
+├── Entities/                            # Models
+├── Http/
+│   ├── Controllers/
+│   ├── Middleware/
+│   ├── Requests/
+│   └── Resources/
+├── Livewire/
+├── Providers/
+│   ├── {Module}ServiceProvider.php
+│   ├── EventServiceProvider.php
+│   └── RouteServiceProvider.php
+├── Resources/
+│   ├── assets/{css,js}
+│   ├── lang/{en,id}
+│   └── views/
+├── Routes/{api.php,web.php}
+├── Services/
+├── Tests/
+│   ├── Feature/
+│   ├── Unit/
+│   └── Pest.php
+├── composer.json                        # MUST exist (for distribution)
+├── module.json                          # MUST exist
+├── package.json                         # If module has frontend assets
+├── CHANGELOG.md                         # MUST exist
+└── README.md                            # MUST exist
+```
+
+### 6.3 Mandatory conventions
+
+#### 6.3.1 Database
+
+- **Table prefix MUST match module slug**: `crm_clients`, `billing_invoices`, `assets_domains`. Never bare names.
+- **Migration filename MUST include module prefix**:
+  ```
+  2026_05_01_100000_crm_create_clients_table.php
+  ```
+- **Foreign keys to core User table use `users` (no prefix)**. Document in module's README which core tables are touched.
+- **Cross-module foreign keys MUST be soft references** (no FK constraint) and resolved via service layer, to keep modules independently disable-able.
+- **Every migration MUST be reversible** (`down()` implemented and tested). Exception: data backfills that destroy data (see §6.7).
+
+#### 6.3.2 Routes
+
+- **Web routes prefix**: `/admin/{module-slug}` for admin, `/{module-slug}` for public.
+- **Route names prefix**: `admin.{module}.` or `{module}.`.
+- **API routes**: `/api/v{N}/{module-slug}` with version bump on breaking changes.
+
+#### 6.3.3 Permissions
+
+- **Pattern**: `{module}.{resource}.{action}`
+- **Examples**: `crm.client.view`, `crm.client.create`, `billing.invoice.send`
+- **Seeder**: `{Module}PermissionSeeder` registered via `module.json` providers.
+
+#### 6.3.4 Services & DI
+
+- Business logic **MUST** live in Services, not Controllers/Livewire.
+- Services **SHOULD** depend on interfaces, not concrete classes, when reuse is plausible.
+- Avoid static helpers for business logic; prefer dependency injection for testability.
+
+#### 6.3.5 Events & hooks
+
+- Modules **MUST** emit Laravel events for significant state changes (`InvoicePaid`, `DomainRenewed`).
+- Cross-module integration **MUST** use events or eventy hooks — never direct calls into another module's internals.
+- Hook names **MUST** be namespaced: `eventy('crm.client.menu', $items)`.
+
+### 6.4 Module quality gates
+
+A module **MUST** ship with:
+
+- [ ] Unit tests for services (≥70% line coverage of Service classes).
+- [ ] Feature tests for HTTP endpoints (happy path + auth/validation failures).
+- [ ] PHPStan level ≥6 clean.
+- [ ] Pint clean.
+- [ ] Migrations run + rollback successfully on fresh DB.
+- [ ] Permissions seeded correctly.
+- [ ] Minimum ID + EN translations.
+
+### 6.5 Module documentation
+
+Each module's `README.md` **MUST** include:
+
+1. Purpose (1 paragraph).
+2. Dependencies (other modules, composer packages, external services).
+3. Installation steps if not via Composer.
+4. Configuration (env vars, config keys).
+5. Permissions list.
+6. Public API surface (events, hooks, commands).
+7. Database tables created.
+8. Known limitations.
+9. Compatibility matrix (Laravel version, base version).
+
+### 6.6 Module lifecycle
+
+```
+[Draft] → [In-project] → [Stabilized] → [Extracted] → [Published] → [Deprecated] → [Sunset]
+```
+
+**Promotion criteria:**
+
+| Transition | Required evidence |
+|---|---|
+| Draft → In-project | Passes module quality gates §6.4 |
+| In-project → Stabilized | Used in 2+ projects with no source changes for ≥1 quarter |
+| Stabilized → Extracted | ADR justifying extraction; SemVer plan |
+| Extracted → Published | Public docs, support process documented |
+| Published → Deprecated | See §6.8 |
+| Deprecated → Sunset | See §6.8 |
+
+### 6.7 Module versioning & migration coordination (NEW in v1.1)
+
+This section addresses a gap in v1.0 that becomes critical when modules are shared across projects: **how do you coordinate database migrations when Project A uses module v1.0 and Project B uses module v2.0?**
+
+#### 6.7.1 Migration types
+
+| Migration type | Description | Rule |
+|---|---|---|
+| **Additive** | Add column, table, index | Safe in MINOR version bump |
+| **Backward-compatible alter** | Widen column, add nullable, increase limit | Safe in MINOR |
+| **Backward-incompatible alter** | Drop column, rename, change type, NOT NULL on existing | **MUST** be MAJOR version bump |
+| **Data backfill** | Populate new column, migrate format | **MUST** be reversible OR documented as forward-only |
+
+#### 6.7.2 The two-phase migration pattern
+
+For backward-incompatible changes, **MUST** use two-phase migration to allow zero-downtime deploy and version overlap:
+
+**Example: renaming `crm_clients.email` to `crm_clients.primary_email`.**
+
+❌ Wrong (v2.0 breaks v1.x consumers):
+```php
+// Single migration in v2.0
+$table->renameColumn('email', 'primary_email');
+```
+
+✅ Right (two-phase):
+```php
+// v1.5.0 (deprecation phase) — additive only
+Schema::table('crm_clients', function (Blueprint $table) {
+    $table->string('primary_email')->nullable()->after('email');
+});
+// + Service layer reads from primary_email if set, else email
+// + Backfill job copies email → primary_email
+// + Mark email field deprecated in @property docblocks
+
+// v2.0.0 (removal phase, after 1+ quarter and all consumers migrated) — breaking
+Schema::table('crm_clients', function (Blueprint $table) {
+    $table->dropColumn('email');
+});
+```
+
+#### 6.7.3 Migration ordering when modules share consumers
+
+When Project K depends on `module-vault@^1.0` and `module-billing@^2.0`, and both have migrations, ordering matters:
+
+- Migration timestamp **MUST** reflect when the migration was created in the module's history, not project import time.
+- If migrations from different modules conflict (rare — should be impossible if §6.3.1 table prefix rule is honored), the conflict is a **module-level bug** and **MUST** trigger a release in the conflicting module.
+
+#### 6.7.4 Module compatibility matrix (mandatory in module README)
+
+Every module **MUST** document compatibility:
+
+```markdown
+## Compatibility
+
+| Module Vault | Laravel | Pesantech base | nwidart/laravel-modules | Notes |
+|---|---|---|---|---|
+| 1.0.x | ^13.0 | ^1.0 | ^13.0 | Initial release |
+| 2.0.x | ^13.0,^14.0 | ^1.1 | ^13.0,^14.0 | Adds two-phase migration support |
+```
+
+#### 6.7.5 Forward-only migrations (when `down()` is impossible)
+
+Some migrations cannot be reversed (data loss, destructive transformation). These **MUST**:
+
+1. Be explicitly marked in the migration file:
+   ```php
+   /**
+    * FORWARD-ONLY: This migration cannot be reverted.
+    * Reason: Encrypts plaintext credentials; rolling back would re-expose them.
+    * Mitigation: Backup database before deploying.
+    */
+   ```
+2. Be announced in the CHANGELOG as a breaking change.
+3. Trigger a MAJOR version bump.
+4. Have `down()` implemented as `throw new \LogicException('FORWARD-ONLY migration')`.
+
+### 6.8 Module deprecation & sunset policy (NEW in v1.1)
+
+When a module is replaced, fundamentally changed, or no longer maintained, it enters deprecation. This section defines the procedure.
+
+#### 6.8.1 Deprecation timeline
+
+| Phase | Duration | Communication |
+|---|---|---|
+| **Announcement** | T-0 | CHANGELOG entry; README banner; email to consumer maintainers |
+| **Deprecation** | T+0 to T+90 days minimum | Version bump (MINOR); deprecation warnings in code; alternative documented |
+| **Maintenance-only** | T+90 to T+180 days | Only critical bug fixes & security patches |
+| **Sunset** | T+180 days+ | No support; final security patch promised; archive label on repo |
+
+For modules used in production by ≥1 paying customer, **timeline MUST extend to 12 months minimum** in deprecation + maintenance-only phases.
+
+#### 6.8.2 Deprecation announcement (mandatory contents)
+
+```markdown
+## DEPRECATED — module-{name}
+
+**As of v{X.Y.Z} ({date}), this module is deprecated.**
+
+**Reason:** [Why deprecated. E.g., replaced by module-{newer}, technology shift, security architecture change.]
+
+**Migration path:** [How consumers should migrate. Concrete steps.]
+
+**Timeline:**
+- T+0 ({date}): Deprecation announced.
+- T+90 days ({date}): Last feature release. Maintenance-only thereafter.
+- T+180 days ({date}): Sunset. Repository archived. No further updates.
+
+**Affected consumers:** [List known consumer projects.]
+
+**Questions:** [contact email or issue tracker]
+```
+
+#### 6.8.3 Code-level deprecation markers
+
+**Class deprecation:**
+```php
+/**
+ * @deprecated since v1.5.0, will be removed in v2.0.0. Use {NewClass} instead.
+ */
+class OldVaultService { ... }
+```
+
+**Method deprecation:**
+```php
+/**
+ * @deprecated since v1.5.0, will be removed in v2.0.0. Use revealCredentialV2() instead.
+ */
+public function revealCredential() {
+    trigger_deprecation('pesantechid/module-vault', '1.5.0', 
+        'Method %s is deprecated, use revealCredentialV2() instead.', __METHOD__);
+    return $this->revealCredentialV2();
+}
+```
+
+#### 6.8.4 Forbidden during deprecation
+
+- ❌ **MUST NOT** introduce new features into a deprecated module after deprecation announcement.
+- ❌ **MUST NOT** remove deprecated methods/classes before timeline ends.
+- ❌ **MUST NOT** sunset a module without first going through deprecation phase.
+
+---
+
+## 7. Module Sharing & Distribution
+
+### 7.1 Three strategies, when to use each
+
+| Strategy | Use when | Maintenance cost | Reusability |
+|---|---|---|---|
+| **A — In-project only** | Module is in Draft or In-project lifecycle | Low | Zero |
+| **B — Composer VCS package** | Stabilized, used in 2–4 projects, internal | Medium | High |
+| **C — Private Packagist / Public Packagist** | Stabilized + Productized, 5+ projects or external consumers | Higher (release engineering) | Highest |
+
+**Default progression: A → B → C.** Skipping requires ADR.
+
+### 7.2 Strategy B — Composer VCS
+
+#### 7.2.1 Extract module to its own repo
+
+```bash
+cd modules/Vault
+git init
+git add .
+git commit -m "chore: extract Vault module"
+gh repo create pesantechid/module-vault --private --source=. --push
+```
+
+#### 7.2.2 Module's `composer.json`
+
+```json
+{
+  "name": "pesantechid/module-vault",
+  "description": "Encrypted credential vault module for Pesantech Framework",
+  "type": "laravel-module",
+  "license": "proprietary",
+  "require": {
+    "php": "^8.3",
+    "illuminate/support": "^13.0",
+    "nwidart/laravel-modules": "^13.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Modules\\Vault\\": "src/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": ["Modules\\Vault\\Providers\\VaultServiceProvider"]
+    }
+  }
+}
+```
+
+#### 7.2.3 Consumer project's `composer.json`
+
+```json
+{
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@github.com:pesantechid/module-vault.git"
+    }
+  ],
+  "require": {
+    "pesantechid/module-vault": "^1.0"
+  }
+}
+```
+
+### 7.3 Strategy C — Private Packagist
+
+Required when:
+- Module sold to external customers, OR
+- 5+ internal projects depend on it, OR
+- Build performance becomes concern (VCS resolves slowly with many packages).
+
+### 7.4 Versioning policy (SemVer)
+
+| Change type | Version bump | Examples |
+|---|---|---|
+| Breaking (DB schema removal, public API removal, behavior change) | Major (1.x → 2.0) | Drop field, rename event class |
+| Backward-compatible feature | Minor (1.0 → 1.1) | Add field, add endpoint |
+| Backward-compatible fix | Patch (1.0.0 → 1.0.1) | Bug fix, performance improvement |
+
+**Pre-1.0 (`0.x.y`):** anything goes; minor counts as breaking. Reach 1.0 after ≥1 month stable in production.
+
+### 7.5 Cross-module compatibility matrix
+
+When modules depend on each other, declare in `module.json`:
+
+```json
+{
+  "name": "Reports",
+  "requires": {
+    "Crm": "^1.0",
+    "Billing": "^1.2"
+  }
+}
+```
+
+Maintain a master compatibility matrix in `pesantechid/pesantech-framework` wiki when 5+ modules exist.
+
+---
+
+## 8. Branching, Tagging & Release Engineering
+
+### 8.1 Branch model
+
+**Trunk-based development** with short-lived feature branches. **MUST NOT** use long-running develop/staging branches.
+
+Branch naming:
+- `feat/{ticket-id}-short-desc` — new feature
+- `fix/{ticket-id}-short-desc` — bug fix
+- `chore/short-desc` — non-functional (deps, CI, docs)
+- `refactor/short-desc` — refactoring without behavior change
+- `docs/short-desc` — documentation only
+
+### 8.2 Commit conventions
+
+**Conventional Commits** enforced via Commitlint (already in upstream):
+
+```
+<type>(<scope>): <subject>
+
+<body — what & why, not how>
+
+<footer — refs, breaking changes>
+```
+
+### 8.3 PR workflow
+
+1. Branch from `main`.
+2. Make changes; commit with Conventional Commits.
+3. Run `composer test` locally before push.
+4. Push; open PR using template.
+5. PR template enforces:
+   - [ ] Linked issue/ticket
+   - [ ] Tests added/updated
+   - [ ] Migrations reversible (or marked forward-only per §6.7.5)
+   - [ ] Permissions seeded (if new)
+   - [ ] Documentation updated
+   - [ ] No core file modified (or ADR linked)
+6. CI must be green.
+7. ≥1 review approval (self-review acceptable for solo dev when team size 1; mandatory separate reviewer when team size ≥2).
+8. Squash-merge.
+
+### 8.4 Tagging & releases
+
+```bash
+git tag -a v1.4.0 -m "Release v1.4.0: monthly report PDF generator"
+git push origin --tags
+```
+
+**Build metadata** for tracking base version (recommended):
+
+```
+v1.4.0+base-1.0.2+laradashboard-1.2.0
+```
+
+Releases **MUST** be created via GitHub Releases UI or `gh release create` with autogenerated changelog from Conventional Commits.
+
+---
+
+## 9. Quality Gates & CI/CD
+
+### 9.1 Mandatory gates
+
+Every PR **MUST** pass:
+
+| Gate | Tool | Failure threshold |
+|---|---|---|
+| Code style | Laravel Pint | Any violation |
+| Static analysis | PHPStan (Larastan) | Level 6, no new errors |
+| Type/refactor checks | Rector (dry-run) | No undeclared changes |
+| Unit + Feature tests | Pest | <100% pass |
+| Browser tests | Pest browser plugin | <100% pass (when applicable) |
+| JS lint | ESLint | Any violation |
+| JS types (if TS) | tsc | Any error |
+| Dependency audit | `composer audit`, `npm audit` | High/Critical CVE |
+| Secret scanning | gitleaks (CI) | Any finding |
+| Migration reversibility | Custom Pest test | Up + down + up cycle on fresh DB |
+
+### 9.2 Reusable CI workflow
+
+Stored in L1 base at `.github/workflows/ci.yml`. Every project inherits via "Use this template" and **MAY** extend.
+
+```yaml
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: secret
+          MYSQL_DATABASE: testing
+        ports: ['3306:3306']
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+      redis:
+        image: redis:7
+        ports: ['6379:6379']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, mysql, redis, gd, intl, bcmath, zip
+          coverage: pcov
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'npm' }
+
+      - name: Composer install
+        run: composer install --no-progress --prefer-dist --no-interaction
+
+      - name: Env setup
+        run: |
+          cp .env.example .env.testing
+          php artisan key:generate --env=testing
+
+      - name: Migrate (forward)
+        run: php artisan migrate --env=testing
+
+      - name: Migrate rollback test
+        run: |
+          php artisan migrate:rollback --env=testing
+          php artisan migrate --env=testing
+
+      - name: Pint
+        run: composer pint
+
+      - name: PHPStan
+        run: composer phpstan
+
+      - name: Rector dry-run
+        run: ./vendor/bin/rector process --dry-run
+
+      - name: Pest
+        run: composer pest
+
+      - name: NPM
+        run: |
+          npm ci
+          npm run lint
+          npm run build
+
+      - name: Composer audit
+        run: composer audit --abandoned=report
+
+      - name: NPM audit
+        run: npm audit --audit-level=high
+```
+
+### 9.3 Branch protection ruleset
+
+Apply to `main` of every project:
+
+- ☑ Require PR before merge (1 approval)
+- ☑ Require status checks: `quality`
+- ☑ Require branches up-to-date before merge
+- ☑ Require signed commits (recommended)
+- ☑ Restrict force-pushes
+- ☑ Restrict deletions
+
+### 9.4 Deployment pipeline
+
+**Staging** (continuous):
+- Trigger: every push to `main`.
+- Action: build container → push to registry → deploy via SSH or ArgoCD.
+- Smoke test: `curl /health` returns 200, `php artisan migrate --pretend` works.
+
+**Production** (gated):
+- Trigger: tag matching `v*.*.*` is created.
+- Action: same as staging + DB backup before migrate.
+- Manual approval **MUST** be required (GitHub Environments → required reviewers).
+
+---
+
+## 10. Performance Engineering
+
+### 10.1 Performance philosophy
+
+**Measure before optimizing.** Premature optimization is debt.
+
+### 10.2 Performance budgets
+
+| Metric | Budget |
+|---|---|
+| TTFB (p50) admin | < 300 ms |
+| TTFB (p95) admin | < 800 ms |
+| LCP (p75) client portal | < 2.5 s |
+| API JSON response (p95) | < 500 ms |
+| Database queries per page (admin) | < 30 |
+| Database queries per page (client portal) | < 15 |
+| Memory per request | < 64 MB |
+| Background job throughput | ≥ 100 jobs/min/worker |
+
+### 10.3 Runtime: PHP-FPM vs Octane
+
+| Scenario | Recommended | Rationale |
+|---|---|---|
+| <50 concurrent users, simple CRUD | PHP-FPM | Simpler, no state-leak risk |
+| ≥50 concurrent users OR latency-sensitive | Octane + FrankenPHP | 3–10x throughput |
+| Heavy real-time / WebSockets | Octane + Swoole | Coroutine support |
+| Need Xdebug / aggressive debugging | RoadRunner OR PHP-FPM | FrankenPHP/Swoole degrade dev experience |
+
+**Default for new Pesantech projects: start with PHP-FPM. Promote to Octane+FrankenPHP after first load test or when budgets exceeded.**
+
+### 10.4 Caching strategy
+
+| Layer | Technology | Use for |
+|---|---|---|
+| OPcache | PHP built-in | Bytecode (always on in prod) |
+| Application cache | Redis | DB query results, settings, computed views |
+| Route/config cache | Laravel artisan cache | Production deploys (`php artisan optimize`) |
+| HTTP cache | Cloudflare / CDN | Static assets, public pages |
+| View cache | Laravel | Compiled Blade (always on in prod) |
+
+**Cache invalidation rules:**
+- Tagged caches via `Cache::tags()` for hierarchical invalidation.
+- Model changes invalidate via Observer pattern.
+- TTL **MUST** be set explicitly; no infinite caches except for genuinely immutable data.
+
+### 10.5 Database optimization checklist
+
+For every new module:
+
+- [ ] Foreign keys indexed.
+- [ ] Common WHERE columns indexed.
+- [ ] Common ORDER BY columns indexed.
+- [ ] Composite indexes for multi-column WHERE.
+- [ ] N+1 queries verified absent.
+- [ ] `select(['col1', 'col2'])` for large tables.
+- [ ] Pagination on all list queries.
+- [ ] Bulk operations use `chunk()` or `lazy()` for >1000 rows.
+
+### 10.6 Frontend optimization
+
+- Vite production build with `--minify`.
+- Tailwind purge enabled.
+- Code-splitting per route (Livewire 4 supports this).
+- Lazy-load heavy components.
+- Image: WebP/AVIF with fallback; lazy `loading="lazy"`.
+
+### 10.7 Monitoring & alerts
+
+| Tool | Purpose | Environment |
+|---|---|---|
+| Laravel Pulse | Internal metrics dashboard | Staging + Production (sampled 1%) |
+| Laravel Telescope | Request inspection | **Staging only** (`TELESCOPE_ENABLED=false` in prod) |
+| Sentry / Bugsnag | Error tracking | Production |
+| Uptime check (UptimeRobot, BetterStack) | External availability | Production |
+| Server metrics (Netdata, Grafana) | CPU, memory, disk | Production |
+
+**Alert thresholds:**
+- Error rate > 1% over 5 min
+- p95 TTFB > 2s over 5 min
+- Disk > 85%
+- Failed jobs > 10 in 5 min
+- Down for >1 min
+
+---
+
+## 11. Security Baseline
+
+### 11.1 OWASP alignment
+
+Every project **MUST** address OWASP Top 10 (current edition).
+
+### 11.2 Authentication & authorization
+
+- 2FA (TOTP) **MUST** be available for all admin/staff roles.
+- Password requirements: min 12 chars, no max, breached-password check (HIBP API).
+- Session timeout: 8 hours idle, 7 days absolute.
+- All routes default-deny — explicit `auth` middleware.
+- Spatie Permission with policies, never `if ($user->is_admin)` checks.
+- Sanctum tokens scoped per integration.
+
+### 11.3 Secrets management
+
+- **MUST NOT** commit secrets, even fake ones, beyond what upstream ships.
+- Production secrets stored in: GitHub Actions Secrets, server `.env` (chmod 600), or vault service (HashiCorp Vault for K8s).
+- Database backups encrypted at rest (age, sops, or built-in cloud).
+
+### 11.4 Secrets rotation procedure (NEW in v1.1)
+
+This section is critical because Vault-type modules encrypt customer credentials with `APP_KEY`. Rotation **without procedure** = data loss.
+
+#### 11.4.1 Rotation calendar
+
+| Secret | Rotation cadence | Triggered immediately on |
+|---|---|---|
+| `APP_KEY` | Annual + on suspicion of compromise | Suspected compromise; departing engineer with access |
+| Database password | Quarterly | Suspected compromise; departing engineer with access |
+| API tokens (Cloudflare, Telegram bot, etc.) | Quarterly OR on personnel change | Same as above |
+| TLS certificates | Auto via Let's Encrypt (90-day) | N/A |
+| 2FA backup codes (per user) | On personnel change | Same as above |
+
+#### 11.4.2 `APP_KEY` rotation procedure (CRITICAL)
+
+`APP_KEY` rotation is destructive if mishandled because Laravel's `Crypt` facade uses it to decrypt all encrypted data (including encrypted casts in models).
+
+**MUST** follow this procedure:
+
+```bash
+# Phase 1: Preparation (runs against production replica)
+# 1. Identify all encrypted data
+php artisan tinker
+>>> // List models with encrypted casts
+>>> // Document affected tables and columns
+
+# 2. Take a fresh, verified backup
+mysqldump --single-transaction kendali_prod > backup-pre-rotation-$(date +%Y%m%d).sql
+# Encrypt the backup
+age -r $(cat backup-recipients.txt) backup-pre-rotation-*.sql > backup-pre-rotation-$(date +%Y%m%d).sql.age
+# VERIFY restore works on staging
+```
+
+```bash
+# Phase 2: Re-encryption (in a maintenance window)
+# 1. Generate new key (do NOT replace yet)
+NEW_KEY=$(php artisan key:generate --show)
+
+# 2. Add new key as secondary
+# Laravel supports APP_PREVIOUS_KEYS for rotation:
+#   .env:
+#     APP_KEY=base64:NEW...
+#     APP_PREVIOUS_KEYS=base64:OLD...
+
+# 3. Run re-encryption command (must be implemented in Vault module)
+php artisan vault:reencrypt --confirm
+# This iterates encrypted columns, decrypts with old, re-encrypts with new
+
+# 4. After verification, remove APP_PREVIOUS_KEYS
+```
+
+#### 11.4.3 Required: Vault module re-encryption command
+
+Every module that uses encrypted casts **MUST** ship with a re-encryption Artisan command:
+
+```php
+// modules/Vault/Console/Commands/ReencryptCommand.php
+class ReencryptCommand extends Command
+{
+    protected $signature = 'vault:reencrypt {--confirm} {--chunk=100}';
+    
+    public function handle()
+    {
+        if (!$this->option('confirm')) {
+            $this->error('Run with --confirm to proceed. Backup database first.');
+            return 1;
+        }
+        
+        Credential::chunk($this->option('chunk'), function ($creds) {
+            foreach ($creds as $cred) {
+                // Force re-encryption by saving (Laravel handles this if APP_PREVIOUS_KEYS set)
+                $cred->touch();
+                $cred->save();
+            }
+        });
+    }
+}
+```
+
+#### 11.4.4 Rotation drill (mandatory)
+
+- **Quarterly:** rotate non-critical secret (e.g., a test API token) end-to-end.
+- **Annually:** full rotation drill on staging including `APP_KEY`. Document results.
+- **MUST** test restore from backup before any production rotation.
+
+### 11.5 Data protection
+
+- All PII fields encrypted at rest using Laravel encrypted casts.
+- Credentials/tokens in vault module use envelope encryption (per-tenant DEK + master KEK).
+- TLS 1.2+ only; HSTS preload.
+- CSP strict policy; nonce-based.
+- Database SSL connection in production.
+
+### 11.6 Dependency hygiene
+
+- Dependabot enabled.
+- `composer audit` and `npm audit` in CI; high/critical = build failure.
+- Quarterly manual review of all dependencies.
+
+### 11.7 Logging & audit
+
+- All write operations to sensitive entities logged via `ActionLog` (already in base).
+- Logs **MUST NOT** contain PII or secrets — use Laravel's `dontFlash` + custom scrubber.
+- Audit log retention: minimum 1 year.
+- Failed login attempts logged + rate-limited (5/15min/IP, 5/15min/account).
+
+### 11.8 Email deliverability (NEW in v1.1)
+
+Email-sending products require operational setup beyond app code. Without this, emails go to spam — invoices unread, reminders unseen.
+
+#### 11.8.1 DNS setup (mandatory before sending production email)
+
+For domain `kendali.in` (and any sender domain):
+
+| Record | Purpose | Example |
+|---|---|---|
+| **SPF** (TXT) | Authorized senders | `v=spf1 include:spf.postmarkapp.com ~all` |
+| **DKIM** (TXT) | Cryptographic signature | Provided by mail provider |
+| **DMARC** (TXT) | Policy for SPF/DKIM failures | `v=DMARC1; p=quarantine; rua=mailto:dmarc@kendali.in; pct=100` |
+| **MX** | Receive bounces/replies | Postmark MX or self-hosted |
+
+**MUST** verify all four records via:
+```bash
+dig TXT kendali.in
+dig TXT _dmarc.kendali.in
+dig TXT [selector]._domainkey.kendali.in
+```
+
+**MUST** use a deliverability tester (mail-tester.com, Postmark check) before first production send. Target score: 9/10 minimum.
+
+#### 11.8.2 Domain warm-up
+
+New domains have zero reputation. Sending 1000 invoices on day 1 → spam.
+
+**Warm-up schedule:**
+
+| Days | Daily volume cap |
+|---|---|
+| 1–7 | 50 |
+| 8–14 | 200 |
+| 15–30 | 1,000 |
+| 30+ | Per provider limits |
+
+#### 11.8.3 Provider choice
+
+| Provider | Strengths | Cost (2026, ~) |
+|---|---|---|
+| **Postmark** | Best transactional deliverability, fast support | $15/mo for 10k |
+| **AWS SES** | Cheapest at scale | $0.10 / 1k |
+| **Mailgun** | Decent deliverability, EU region available | $15/mo for 10k |
+| **Resend** | Developer-friendly, modern | $20/mo for 50k |
+
+**Default recommendation for Pesantech:** Postmark for transactional (invoices, alerts). SES for bulk (campaigns).
+
+#### 11.8.4 Bounce & complaint handling
+
+- **MUST** subscribe to provider webhooks for bounces and complaints.
+- **MUST** auto-suppress addresses after hard bounce or complaint.
+- **MUST NOT** retry sending to suppressed addresses.
+
+#### 11.8.5 Sender reputation monitoring
+
+Monitor weekly:
+- Postmaster Tools (Google) — sender reputation.
+- Microsoft SNDS — Outlook reputation.
+- Provider dashboards — bounce rate < 2%, complaint rate < 0.1%.
+
+#### 11.8.6 Content best practices
+
+- **MUST** include unsubscribe link in marketing/campaign emails (legal requirement; transactional invoices exempt but courteous).
+- **MUST NOT** use spammy phrases ("FREE!!!", excessive caps).
+- **MUST** include physical address in marketing emails (UU PDP + CAN-SPAM equivalent).
+- Plain-text alternative alongside HTML.
+
+### 11.9 Indonesia-specific (UU PDP)
+
+- Right-to-export: every project **MUST** expose data export per data subject.
+- Right-to-delete: deletion process documented; soft-delete + hard-delete-after-grace-period pattern.
+- Privacy policy link visible in client portal.
+- DPA template available for B2B clients.
+
+---
+
+## 12. Observability, Operations & Disaster Recovery
+
+### 12.1 Three pillars
+
+| Pillar | Tool | Retention |
+|---|---|---|
+| **Logs** | Laravel log → file → Loki/Papertrail | 30 days hot, 1 year cold |
+| **Metrics** | Pulse + Prometheus | 90 days |
+| **Traces** | OpenTelemetry → Jaeger/Tempo (when scale demands) | 7 days |
+
+### 12.2 Health checks
+
+Every project **MUST** expose:
+
+- `GET /health` — basic liveness, returns 200 if app boots.
+- `GET /health/ready` — readiness, checks DB, Redis, queue connection.
+
+### 12.3 Backup & restore
+
+- DB backup: daily, encrypted, off-site (R2 / S3 / Backblaze).
+- Application files (uploaded media): daily incremental, encrypted, off-site.
+- Retention: 30 days daily, 12 months monthly.
+
+### 12.4 Incident response
+
+- Severity classification:
+  - **SEV1**: full outage, data loss, security breach. Response: <15 min.
+  - **SEV2**: degraded service. Response: <1 hour.
+  - **SEV3**: minor issue. Response: next business day.
+- Postmortem **MUST** be written for SEV1/SEV2 within 1 week, blameless.
+
+### 12.5 Runbooks
+
+Each project **MUST** maintain `OPERATIONS.md` with:
+
+- How to deploy / rollback.
+- How to restore DB.
+- How to access logs.
+- How to scale.
+- Common errors & fixes.
+- On-call rotation (when applicable).
+
+### 12.6 Disaster Recovery (NEW in v1.1)
+
+Disasters happen: VPS host bankruptcy, accidental `DROP DATABASE`, ransomware, region outage. Without a DR plan, "we have backups" is a half-truth.
+
+#### 12.6.1 RTO and RPO targets
+
+| Tier | RTO (Recovery Time Objective) | RPO (Recovery Point Objective) | Use for |
+|---|---|---|---|
+| **Tier 1 — Production SaaS (Phase 3)** | 4 hours | 1 hour | When paying customers depend on uptime |
+| **Tier 2 — Internal production** | 24 hours | 24 hours | Pesantech Phase 1 (single tenant) |
+| **Tier 3 — Internal non-critical** | 1 week | 1 week | Dev/staging |
+
+**RTO** = max time the service can be down before recovery. **RPO** = max data loss acceptable.
+
+For Phase 1 Kendali, Tier 2 applies: max 24h downtime, max 24h data loss.
+
+#### 12.6.2 Backup strategy (3-2-1 rule)
+
+- **3** copies of data
+- **2** different storage media/providers
+- **1** off-site
+
+For Pesantech:
+
+| Backup | Where | Frequency | Encrypted? |
+|---|---|---|---|
+| Primary | VPS local (cron `mysqldump`) | Hourly | No (local) |
+| Secondary | Cloudflare R2 (different region) | Daily | Yes (age) |
+| Tertiary | Backblaze B2 (different provider) | Weekly | Yes (age) |
+
+**Vault data** (encrypted credentials) backed up separately with separate encryption key — protects against compromise of primary backup encryption key.
+
+#### 12.6.3 Restore drill (MANDATORY)
+
+A backup that isn't tested is not a backup.
+
+**Quarterly drill:**
+1. Spin up fresh VPS or container.
+2. Restore latest backup.
+3. Verify application boots.
+4. Verify last 24h of data is present.
+5. Document time taken (must be < RTO).
+6. File drill report in `OPERATIONS.md`.
+
+**Annually:** full DR drill including DNS cutover, certificate provisioning, integrations re-config. Goal: complete recovery from "production lost" scenario in <RTO.
+
+#### 12.6.4 Data classification (informs DR priority)
+
+| Class | Examples | Loss impact | Recovery priority |
+|---|---|---|---|
+| **Critical** | Vault credentials, billing records, audit logs | Legal/financial | 1 (recover first) |
+| **Important** | Client data, reports, tickets | Operational | 2 |
+| **Replaceable** | Cached data, search indexes, sessions | Performance | 3 (rebuild rather than restore) |
+
+#### 12.6.5 Off-VPS dependencies
+
+Track all external dependencies that could fail independently:
+- DNS (registrar)
+- Email provider (Postmark)
+- File storage (R2)
+- TLS certificate (Let's Encrypt)
+- Telegram Bot API
+- Any future payment gateway
+
+For each: document recovery procedure, alternative provider option, and contact.
+
+#### 12.6.6 Communication plan
+
+When disaster strikes:
+- Customers notified within 1 hour (status page or email).
+- ETA updates every 2 hours.
+- Postmortem published within 1 week.
+
+For Phase 1 Kendali (5 clients), a simple Telegram broadcast is sufficient. Phase 3 SaaS needs a real status page (statuspage.io or self-hosted Cachet).
+
+---
+
+## 13. Architecture Decision Records (ADR)
+
+### 13.1 Why ADRs
+
+ADRs capture *why* a decision was made, not just *what*.
+
+### 13.2 When to write an ADR
+
+Mandatory for:
+- Choosing a database, queue driver, or runtime.
+- Adopting/dropping a major dependency.
+- Multi-tenancy strategy.
+- Authentication provider choice.
+- Departures from this playbook.
+- Module extraction to package.
+- Module deprecation.
+- Tier 2 emergency upstream sync (per §4.3.4).
+
+### 13.3 ADR template
+
+Stored at `docs/adr/NNNN-title.md`:
+
+```markdown
+# ADR NNNN — Title
+
+| Status   | Proposed / Accepted / Deprecated / Superseded by ADR-XXXX |
+| Date     | YYYY-MM-DD                                                |
+| Deciders | @maintainer1, @maintainer2                                |
+
+## Context
+What problem are we solving? What forces are at play?
+
+## Decision
+What are we doing? Be specific.
+
+## Consequences
+- Positive: ...
+- Negative: ...
+- Risks & mitigations: ...
+
+## Alternatives considered
+- Option A: rejected because ...
+- Option B: rejected because ...
+
+## References
+- Links, benchmarks, prior art.
+```
+
+### 13.4 ADRs to write at project start (Pesantech standard set)
+
+For every Pesantech project:
+
+1. **ADR-0001**: Adopt this playbook (version pinned).
+2. **ADR-0002**: Base version pinned (record `pesantech-framework@vX.Y.Z+laradashboard-A.B.C`).
+3. **ADR-0003**: Database technology.
+4. **ADR-0004**: Initial runtime (PHP-FPM vs Octane).
+5. **ADR-0005**: Multi-tenancy strategy.
+6. **ADR-0006**: Module taxonomy.
+7. **ADR-0007**: Upstream sync strategy (Tier 1 default per §4.3).
+8. **ADR-0008**: Module versioning & deprecation policy (per §6.7, §6.8).
+9. **ADR-0009**: Secrets rotation procedure (per §11.4).
+
+---
+
+## 14. Glossary & Appendices
+
+### 14.1 Glossary
+
+| Term | Definition |
+|---|---|
+| **Base** | The pesantech-framework template (L1) — never directly used as project. |
+| **Project** | A concrete product instance (L2). |
+| **Module** | An installable, self-contained business capability under `modules/`. |
+| **Workspace** | Isolated tenant within a multi-tenant project (Phase 2+). |
+| **ADR** | Architecture Decision Record. |
+| **SemVer** | Semantic Versioning — major.minor.patch. |
+| **DEK / KEK** | Data Encryption Key / Key Encryption Key — envelope encryption pattern. |
+| **RTO / RPO** | Recovery Time Objective / Recovery Point Objective. |
+| **Tier 1/2/3 sync** | Upstream sync source (tag/release-branch/main) per §4.3. |
+
+### 14.2 Tooling versions (as of 2026-05)
+
+| Component | Version |
+|---|---|
+| PHP | 8.3 / 8.4 |
+| Laravel | 13.x |
+| Livewire | 4.x |
+| Tailwind | 4.x |
+| nwidart/laravel-modules | 13.x |
+| spatie/laravel-permission | 6.4+ |
+| MySQL | 8.4 LTS |
+| Redis | 7.x |
+| Node.js | 20.19+ |
+| FrankenPHP | 1.x |
+| Octane | 2.x |
+| stancl/tenancy (when adopted) | 3.10+ |
+| laravel/pennant (feature flags) | 1.x |
+
+### 14.3 Quick reference cheatsheet
+
+```bash
+# Bootstrap project
+gh repo create pesantechid/PROJECT --template pesantechid/pesantech-framework --private
+git clone git@github.com:pesantechid/PROJECT.git && cd PROJECT
+git remote add base https://github.com/pesantechid/pesantech-framework.git
+
+cp .env.example .env && composer install && npm install
+php artisan key:generate
+php artisan migrate:fresh --seed && php artisan module:seed
+
+# Daily dev
+composer dev
+
+# Module ops
+php artisan module:make Crm
+php artisan module:make-crud Client Crm
+php artisan module:list
+php artisan module:enable Crm
+php artisan module:disable Crm
+php artisan module:zip Crm
+
+# Quality
+composer pint
+composer phpstan
+composer pest
+composer test
+
+# Sync upstream → base (TAG-based per §4.3)
+cd pesantech-framework
+git fetch upstream --tags
+git merge v1.1.3 --no-ff   # use specific tag, not branch
+
+# Sync base → project
+cd PROJECT
+git fetch base --tags
+git merge v1.1.0+laradashboard-1.2.0 --no-ff
+
+# Production deploy
+git tag -a v1.4.0 -m "Release v1.4.0"
+git push origin --tags
+```
+
+### 14.4 Common pitfalls & remedies
+
+| Pitfall | Symptom | Remedy |
+|---|---|---|
+| Editing `app/Models/User.php` | Conflicts on every base sync | Use UserMeta or extend in module |
+| Module table named bare (e.g., `clients`) | Conflict in shared modules | Always prefix: `crm_clients` |
+| Forgetting permission seeder | Missing perms in production | Module-level `PermissionSeeder` registered in `module.json` |
+| Telescope/Pulse on in production | Performance + info disclosure | `.env` `TELESCOPE_ENABLED=false`, verified pre-prod |
+| Cross-module direct dependency | Cannot disable one module | Use events or hooks |
+| Octane state leak | Random user data in wrong session | Audit static properties; flush in `RequestHandled` listener |
+| Tracking upstream `main` | Unreproducible builds, no audit trail | Use tag (Tier 1 per §4.3) |
+| `APP_KEY` rotation without procedure | Encrypted data lost | Follow §11.4.2 procedure |
+| Email goes to spam | Invoices unread | Setup SPF/DKIM/DMARC + warm-up per §11.8 |
+| Backup never tested | Discovery during real outage that backup is corrupt | Quarterly restore drill per §12.6.3 |
+| Module v2 breaking changes | Consumer projects stuck on v1 | Two-phase migration per §6.7.2 |
+
+### 14.5 References
+
+- Laravel 13 Release Notes — https://laravel.com/docs/13.x/releases
+- nwidart/laravel-modules — https://laravelmodules.com
+- Laravel Octane — https://laravel.com/docs/13.x/octane
+- stancl/tenancy — https://tenancyforlaravel.com
+- Conventional Commits — https://www.conventionalcommits.org
+- Keep a Changelog — https://keepachangelog.com
+- ADR pattern — https://adr.github.io
+- OWASP Top 10 — https://owasp.org/Top10/
+- 3-2-1 Backup Rule — https://www.backblaze.com/blog/the-3-2-1-backup-strategy/
+
+---
+
+## 15. Feature Flags & Progressive Delivery (NEW in v1.1)
+
+### 15.1 Why feature flags
+
+Feature flags decouple deploy from release. Code can be deployed to production with a feature **off**, then turned on for selected users/tenants/percentages. This enables:
+
+- **Safer launches** — kill switch if something breaks.
+- **Gradual rollout** — 1% → 10% → 100%.
+- **A/B testing** — measure impact before full rollout.
+- **Tenant-specific features** (Phase 3 SaaS) — beta features for selected workspaces.
+- **Trunk-based development** — long-running feature work without long branches.
+
+### 15.2 Tooling: laravel/pennant
+
+Use **laravel/pennant** (first-party, lightweight):
+
+```bash
+composer require laravel/pennant
+php artisan vendor:publish --provider="Laravel\Pennant\PennantServiceProvider"
+php artisan migrate
+```
+
+### 15.3 Flag naming convention
+
+Pattern: `{module}.{feature}` or `{scope}.{feature}`
+
+Examples:
+- `reports.llm-conclusion-draft` — LLM-assisted conclusion in Reports module
+- `billing.online-payment` — payment gateway integration
+- `client-portal.ticket-submission` — ticket submission for clients
+- `experimental.new-dashboard` — UI experiments
+
+### 15.4 Flag lifecycle
+
+```
+Created (off, in code) → Beta (selective on) → GA (default on) → Removed
+```
+
+**Every flag MUST have:**
+- Owner (named person/team)
+- Created date
+- Removal target date (default: 90 days post-GA)
+
+**Flag debt is real.** Flags left in code indefinitely become dead branches and confuse readers. **MUST** schedule flag removal.
+
+### 15.5 Flag definition
+
+```php
+// In a service provider
+use Laravel\Pennant\Feature;
+
+Feature::define('reports.llm-conclusion-draft', function ($user) {
+    // Default: only super admins
+    return $user->hasRole('super-admin');
+});
+
+// Per-tenant flag (Phase 3)
+Feature::define('billing.online-payment', function ($workspace) {
+    return $workspace->is_beta_tester;
+});
+
+// Percentage rollout
+Feature::define('client-portal.ticket-submission', function ($user) {
+    return Lottery::odds(1, 10); // 10%
+});
+```
+
+### 15.6 Flag usage
+
+```php
+if (Feature::active('reports.llm-conclusion-draft')) {
+    $conclusion = $this->llmService->draftConclusion($report);
+}
+```
+
+In Blade:
+```blade
+@feature('reports.llm-conclusion-draft')
+    <button>Generate AI conclusion</button>
+@endfeature
+```
+
+### 15.7 Flag types & when to use each
+
+| Flag type | Lifetime | Purpose |
+|---|---|---|
+| **Release flag** | Days–weeks | Decouple deploy from launch |
+| **Experiment flag** | Weeks | A/B test |
+| **Permission flag** | Permanent | "Beta tier" feature gating (becomes permission, not flag) |
+| **Ops flag** | Indefinite | Kill switch (long-lived, but documented) |
+| **Permission flag** | Permanent | If permanent, **MUST** be migrated to RBAC permission instead |
+
+### 15.8 Phase 1 minimum
+
+For Pesantech Phase 1 (Kendali), minimal feature flag setup:
+
+- [ ] `laravel/pennant` installed.
+- [ ] Flag table migrated.
+- [ ] Convention documented in project README.
+- [ ] At least 2 flags in use (e.g., one release flag, one ops kill switch).
+
+Don't over-invest before Phase 3. Just establish the foundation.
+
+---
+
+## 16. AI-Assisted Implementation Standards (NEW in v1.1)
+
+This section addresses the operational reality that Pesantech uses AI agents (Claude Code, Cursor, etc.) for implementation. These standards ensure AI output meets the same quality bar as human-written code.
+
+### 16.1 Why this section exists
+
+AI agents perform best with:
+- **Acceptance criteria that are testable** (not "implement well").
+- **Complete context** (not "developer will know").
+- **Explicit constraints** ("MUST NOT do X" beats "avoid X").
+- **Reference to specific files/modules** (not "the config file").
+
+Without these, AI output drifts: invented APIs, missed edge cases, inconsistent style.
+
+### 16.2 Task specification standard
+
+Every task given to an AI agent **MUST** follow this structure:
+
+```markdown
+## Task: [verb-led, specific]
+
+### Context
+- What this is part of (module name, PRD section, ADR reference)
+- What already exists (file paths, model names)
+- What NOT to touch
+
+### Specification
+- Inputs (data, parameters)
+- Outputs (return types, side effects)
+- Acceptance criteria (testable conditions)
+
+### Constraints
+- Files allowed to modify: [explicit list]
+- Files MUST NOT modify: [explicit list]
+- Style: follow Pint config at .pintrc
+- Tests: MUST add Pest tests covering [scenarios]
+- Migration: MUST be reversible OR mark forward-only per §6.7.5
+
+### References
+- Playbook section(s): [§X.Y]
+- ADR(s): [ADR-NNNN]
+- Module README: [path]
+```
+
+### 16.3 Example task (good)
+
+```markdown
+## Task: Add `assets:refresh-whois` Artisan command to Modules/Assets
+
+### Context
+- Part of Module Assets in Kendali project (PRD §6.2)
+- Existing: `Modules/Assets/Services/WhoisService.php` already exists with method `lookup(string $domain): array`
+- Existing: `Modules/Assets/Entities/AssetDomain.php` model with `last_whois_check_at` column
+- DO NOT modify base Laravel files
+
+### Specification
+**Input:** No arguments. Optional `--client=ID` to scope to one client.
+**Output:** Refreshes `expires_at`, `registrar`, `last_whois_check_at` for all domains where `last_whois_check_at` is null OR > 24h ago.
+**Acceptance criteria:**
+- Command lives at `Modules/Assets/Console/Commands/RefreshWhoisCommand.php`
+- Registered in `Modules/Assets/Providers/AssetsServiceProvider.php`
+- Pest test at `Modules/Assets/Tests/Feature/RefreshWhoisCommandTest.php` covering:
+  - Refreshes domain due for check
+  - Skips domain checked <24h ago
+  - Handles WhoisService failure gracefully (logs, doesn't crash)
+- Updates `last_whois_check_at` even on failure (to prevent retry loop)
+
+### Constraints
+- Files allowed to modify: 
+  - `Modules/Assets/Console/Commands/RefreshWhoisCommand.php` (new)
+  - `Modules/Assets/Providers/AssetsServiceProvider.php`
+  - `Modules/Assets/Tests/Feature/RefreshWhoisCommandTest.php` (new)
+- Files MUST NOT modify: anything outside `Modules/Assets/`
+- Style: Pint
+- Migration: none (no DB schema changes)
+
+### References
+- Playbook: §6.2, §6.3.4 (services), §16 (this section)
+- PRD: §6.2 Module Assets
+```
+
+### 16.4 Example task (bad — what to avoid)
+
+```markdown
+## Task: Add a command to refresh domain expiries
+
+Implement a way to refresh WHOIS data periodically. Make it nice.
+```
+
+**Why this fails:**
+- "A way" — agent invents structure.
+- "Refresh WHOIS data" — agent doesn't know which fields, which tables.
+- "Periodically" — cron? On-demand? Both?
+- "Make it nice" — unmeasurable.
+- No file path, no module, no acceptance criteria, no test requirement.
+
+### 16.5 Review standard for AI-generated PR
+
+Every PR from AI agent **MUST** pass human review for:
+
+| Check | Why |
+|---|---|
+| Did the agent follow file constraints? | AI sometimes "helpfully" modifies adjacent files |
+| Are tests covering claimed scenarios? | AI sometimes writes tests that pass but don't actually test |
+| Are acceptance criteria all met? | Spot-check each one |
+| Are edge cases handled? | AI optimizes for happy path |
+| Is style consistent with codebase? | Style guide compliance |
+| Are there invented APIs? | AI sometimes references methods that don't exist |
+| Are migrations reversible? | AI often skips `down()` |
+| Are deprecation markers present (if applicable)? | AI doesn't auto-add unless told |
+| Does it leak secrets in logs? | Always check |
+
+### 16.6 AI agent instruction header (for repo)
+
+Add to project root as `AGENTS.md` or `CLAUDE.md`:
+
+```markdown
+# AI Agent Instructions for [PROJECT]
+
+## Project context
+- Built on pesantech-framework (Laravel 13 + Livewire 4 + Tailwind 4)
+- Multi-module architecture via nwidart/laravel-modules
+- Read docs/playbook.md before any task
+
+## Hard rules
+1. NEVER modify files in app/, bootstrap/, config/, routes/, database/migrations/ at project root.
+   All custom code lives in modules/.
+2. ALWAYS prefix new tables with module slug (e.g., crm_clients).
+3. ALWAYS write Pest tests for new code.
+4. ALWAYS run `composer pint` and `composer phpstan` after edits.
+5. NEVER commit secrets, even fake ones, in .env.example.
+6. NEVER add features to a deprecated module.
+
+## Style
+- Follow Pint default rules (no overrides unless documented in .pintrc)
+- PHP 8.3 features OK
+- No facades in domain logic (use DI)
+- Service classes for business logic, not Controllers/Livewire
+
+## When unsure
+Ask. Don't invent.
+```
+
+### 16.7 Task batch sizing
+
+| Task complexity | Recommended batch |
+|---|---|
+| **Trivial** (1 file, ≤50 lines) | Direct task, AI implements, human reviews |
+| **Small** (2–5 files, 1 module command) | Task spec + AI implements + AI tests + human reviews |
+| **Medium** (full CRUD, 1 module) | Break into sub-tasks: model+migration, service, controller, views, tests. Human reviews each. |
+| **Large** (full module) | Spec module, break into multi-day sub-tasks. Don't ask AI to "build the whole module" in one go. |
+
+### 16.8 Common AI failure modes & countermeasures
+
+| Failure | Counter |
+|---|---|
+| Inventing methods on existing classes | Provide actual class signatures in task context |
+| Skipping `down()` in migrations | Explicit acceptance criterion |
+| Tests that always pass (no real assertions) | Review test bodies, look for `assertTrue(true)` patterns |
+| Modifying core files "to make it work" | Hard constraint in task; reject PR if violated |
+| Adding new dependencies without justification | Explicit constraint: "no new composer packages without ADR" |
+| Inconsistent style mid-file | Run Pint after merge; fail PR on style violation |
+| Hallucinating Laravel APIs | Cross-check against actual Laravel docs URL in references |
+
+---
+
+## Document control
+
+| Revision | Date | Author | Notes |
+|---|---|---|---|
+| 0.1 | 2026-05-05 | Pesantech | Initial draft (working title: OpsHub) |
+| 1.0 | 2026-05-06 | Pesantech | Approved baseline |
+| **1.1** | **2026-05-07** | **Pesantech** | **Tag-based upstream sync (§4.3 rewritten). Added: §6.7 versioning, §6.8 deprecation, §11.4 secrets rotation, §11.8 email deliverability, §12.6 disaster recovery, §15 feature flags, §16 AI-assisted implementation.** |
+
+**Change process:** amendments via PR to `pesantechid/pesantech-framework` `docs/playbook.md`, requires review by ≥1 maintainer. Major version bumps when fundamental principles change.
+
+*— End of document —*

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,71 @@
+import js from "@eslint/js";
+import prettier from "eslint-config-prettier";
+
+export default [
+    // Ignore build artifacts, vendor, and generated files
+    {
+        ignores: [
+            "vendor/**",
+            "node_modules/**",
+            "public/**",
+            "bootstrap/**",
+            "storage/**",
+            "scripts/**",
+            "*.config.js",
+            "webpack.mix.js",
+            "vite-module-loader.js",
+            "resources/js/lara-builder/**",
+        ],
+    },
+
+    // Base recommended rules
+    js.configs.recommended,
+
+    // Prettier disables formatting rules that conflict with prettier
+    prettier,
+
+    // App browser JS
+    {
+        files: ["resources/**/*.js", "resources/**/*.mjs"],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: "module",
+            globals: {
+                // Browser
+                window: "readonly",
+                document: "readonly",
+                console: "readonly",
+                navigator: "readonly",
+                location: "readonly",
+                localStorage: "readonly",
+                sessionStorage: "readonly",
+                setTimeout: "readonly",
+                clearTimeout: "readonly",
+                setInterval: "readonly",
+                clearInterval: "readonly",
+                requestAnimationFrame: "readonly",
+                cancelAnimationFrame: "readonly",
+                MutationObserver: "readonly",
+                IntersectionObserver: "readonly",
+                ResizeObserver: "readonly",
+                Promise: "readonly",
+                FormData: "readonly",
+                URLSearchParams: "readonly",
+                fetch: "readonly",
+                alert: "readonly",
+                confirm: "readonly",
+                Event: "readonly",
+                CustomEvent: "readonly",
+                HTMLElement: "readonly",
+                // App globals
+                Alpine: "readonly",
+                Livewire: "readonly",
+                axios: "readonly",
+            },
+        },
+        rules: {
+            "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+            "no-console": "off",
+        },
+    },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,9 +2452,10 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-6.0.1.tgz",
+            "integrity": "sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -3703,9 +3704,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -3716,7 +3717,8 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fastify"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -4444,9 +4446,10 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 12"
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,10 +1,8005 @@
 parameters:
 	ignoreErrors:
-		# Laravel model property PHPDoc type covariance issues
-		- '#PHPDoc type array(\<.*\>)? of property .* is not covariant with PHPDoc type .* of overridden property#'
-		
-		# Method exists checks that PHPStan knows are always true
-		- '#Call to function method_exists\(\) with \$this\(.+\) and .+ will always evaluate to true.#'
-		
-		# LengthAwarePaginator contract vs concrete class
-		- '#PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator.#'
+		-
+			message: '#^Method App\\Ai\\Actions\\CreatePostAction\:\:buildBlocks\(\) has parameter \$content with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Actions/CreatePostAction.php
+
+		-
+			message: '#^Method App\\Ai\\Actions\\CreatePostAction\:\:buildBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Actions/CreatePostAction.php
+
+		-
+			message: '#^Method App\\Ai\\Actions\\CreatePostAction\:\:generateImagesForPostWithProgress\(\) has parameter \$content with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Actions/CreatePostAction.php
+
+		-
+			message: '#^Method App\\Ai\\Actions\\CreatePostAction\:\:handleWithProgress\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Actions/CreatePostAction.php
+
+		-
+			message: '#^Method App\\Ai\\Context\\PostContextProvider\:\:getRecentTopics\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Context/PostContextProvider.php
+
+		-
+			message: '#^Method App\\Ai\\Context\\SystemContextProvider\:\:getCurrentUserContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Context/SystemContextProvider.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiIntent\:\:__construct\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiIntent.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiIntent\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiIntent.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiIntent\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiIntent.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiPlan\:\:__construct\(\) has parameter \$steps with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiPlan.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiPlan\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiPlan.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiPlan\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiPlan.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:__construct\(\) has parameter \$actions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:__construct\(\) has parameter \$completedSteps with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:__construct\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:failed\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:partial\(\) has parameter \$actions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:partial\(\) has parameter \$completedSteps with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:partial\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:success\(\) has parameter \$actions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:success\(\) has parameter \$completedSteps with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:success\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiResult\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiResult.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiStep\:\:__construct\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiStep.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiStep\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiStep.php
+
+		-
+			message: '#^Method App\\Ai\\Data\\AiStep\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Data/AiStep.php
+
+		-
+			message: '#^Method App\\Ai\\Engine\\AiCommandProcessor\:\:executeAction\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Engine/AiCommandProcessor.php
+
+		-
+			message: '#^Method App\\Ai\\Engine\\AiCommandProcessor\:\:logCommand\(\) has parameter \$actionMatch with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Engine/AiCommandProcessor.php
+
+		-
+			message: '#^Method App\\Ai\\Engine\\AiCommandProcessor\:\:matchCommandToAction\(\) has parameter \$actions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Engine/AiCommandProcessor.php
+
+		-
+			message: '#^Method App\\Ai\\Engine\\AiCommandProcessor\:\:matchCommandToAction\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Engine/AiCommandProcessor.php
+
+		-
+			message: '#^Method App\\Ai\\Engine\\AiCommandProcessor\:\:parseCommandWithAi\(\) has parameter \$actions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Engine/AiCommandProcessor.php
+
+		-
+			message: '#^Method App\\Ai\\Engine\\AiCommandProcessor\:\:parseCommandWithAi\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Engine/AiCommandProcessor.php
+
+		-
+			message: '#^Method App\\Ai\\Engine\\AiCommandProcessor\:\:sendAiRequest\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Engine/AiCommandProcessor.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\ActionRegistry\:\:all\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/ActionRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\ActionRegistry\:\:getActionsForAi\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/ActionRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\ActionRegistry\:\:getActionsForUser\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/ActionRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\ActionRegistry\:\:registerMany\(\) has parameter \$actionClasses with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/ActionRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\CapabilityRegistry\:\:all\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/CapabilityRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\CapabilityRegistry\:\:enabled\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/CapabilityRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\CapabilityRegistry\:\:getCapabilitiesForAi\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/CapabilityRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\ContextRegistry\:\:all\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/ContextRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\ContextRegistry\:\:getAllContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/ContextRegistry.php
+
+		-
+			message: '#^Method App\\Ai\\Registry\\ContextRegistry\:\:getContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Ai/Registry/ContextRegistry.php
+
+		-
+			message: '#^Method App\\Collections\\ModuleCollection\:\:applyFiltersAndSorting\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Collections/ModuleCollection.php
+
+		-
+			message: '#^Method App\\Collections\\ModuleCollection\:\:get\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Collections/ModuleCollection.php
+
+		-
+			message: '#^Method App\\Collections\\ModuleCollection\:\:loadModuleFromPath\(\) has parameter \$moduleStatuses with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Collections/ModuleCollection.php
+
+		-
+			message: '#^Method App\\Collections\\ModuleCollection\:\:paginate\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Collections/ModuleCollection.php
+
+		-
+			message: '#^Property App\\Collections\\ModuleCollection\:\:\$items with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Collections/ModuleCollection.php
+
+		-
+			message: '#^Property App\\Console\\Commands\\CoreZipCommand\:\:\$excludePatterns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/CoreZipCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\CreatePlaceholderImages\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/CreatePlaceholderImages.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:authenticatedPages\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateAuthenticatedScreenshot\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateAuthenticatedScreenshot\(\) has parameter \$defaultHeight with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateAuthenticatedScreenshot\(\) has parameter \$defaultWidth with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateAuthenticatedScreenshot\(\) has parameter \$route with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateScreenshot\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateScreenshot\(\) has parameter \$defaultHeight with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateScreenshot\(\) has parameter \$defaultWidth with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:generateScreenshot\(\) has parameter \$route with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:guestModePages\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\GenerateScreenshots\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/GenerateScreenshots.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\MakeBuilderBlockCommand\:\:createBlockJson\(\) has parameter \$contexts with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/MakeBuilderBlockCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\MakeBuilderBlockCommand\:\:getAvailableModules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/MakeBuilderBlockCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleCompileCssCommand\:\:buildViteCommand\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleCompileCssCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleCompileCssCommand\:\:getAvailableModules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleCompileCssCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:generateDisplayFieldForColumn\(\) has parameter \$column with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:generateFileFieldBlade\(\) has parameter \$column with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:generateFormFieldForColumn\(\) has parameter \$column with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:generateMediaDisplayFieldBlade\(\) has parameter \$column with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:generateMediaFieldBlade\(\) has parameter \$column with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:generateSelectField\(\) has parameter \$column with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:getEditorFields\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:getTokenReplacements\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:getValidationRule\(\) has parameter \$column with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleMakeCrudCommand\:\:replaceStubTokens\(\) has parameter \$additionalTokens with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Property App\\Console\\Commands\\ModuleMakeCrudCommand\:\:\$columns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleMakeCrudCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModulePackageCommand\:\:generateManifest\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModulePackageCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModulePackageCommand\:\:getModuleInfo\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModulePackageCommand.php
+
+		-
+			message: '#^Property App\\Console\\Commands\\ModulePackageCommand\:\:\$excludePatterns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModulePackageCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModulePublishAssetsCommand\:\:getEnabledModulesWithAssets\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModulePublishAssetsCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleZipCommand\:\:generateManifest\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleZipCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ModuleZipCommand\:\:getModuleInfo\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleZipCommand.php
+
+		-
+			message: '#^Property App\\Console\\Commands\\ModuleZipCommand\:\:\$excludePatterns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ModuleZipCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ProcessInboundEmailsCommand\:\:displayResults\(\) has parameter \$results with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ProcessInboundEmailsCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\ProcessInboundEmailsCommand\:\:hasErrors\(\) has parameter \$results with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/ProcessInboundEmailsCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\SetupStorage\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/SetupStorage.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\TestEmailCommand\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/TestEmailCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\TestEmailTemplateCommand\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Console/Commands/TestEmailTemplateCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\TranslationsExtractCommand\:\:collectFiles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/TranslationsExtractCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\TranslationsExtractCommand\:\:extractStringsFromFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/TranslationsExtractCommand.php
+
+		-
+			message: '#^Method App\\Console\\Commands\\TranslationsExtractCommand\:\:getPatterns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/TranslationsExtractCommand.php
+
+		-
+			message: '#^Property App\\Console\\Commands\\TranslationsExtractCommand\:\:\$excludeDirs type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/TranslationsExtractCommand.php
+
+		-
+			message: '#^Property App\\Console\\Commands\\TranslationsExtractCommand\:\:\$excludeFiles type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/TranslationsExtractCommand.php
+
+		-
+			message: '#^Property App\\Console\\Commands\\TranslationsExtractCommand\:\:\$scanDirs type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Commands/TranslationsExtractCommand.php
+
+		-
+			message: '#^Property App\\Console\\Kernel\:\:\$commands type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Console/Kernel.php
+
+		-
+			message: '#^Method App\\Contracts\\EmailProviderInterface\:\:getFormFields\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Contracts/EmailProviderInterface.php
+
+		-
+			message: '#^Method App\\Contracts\\EmailProviderInterface\:\:getTransportConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Contracts/EmailProviderInterface.php
+
+		-
+			message: '#^Method App\\Contracts\\EmailProviderInterface\:\:getValidationRules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Contracts/EmailProviderInterface.php
+
+		-
+			message: '#^Method App\\Contracts\\HasMediaInterface\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Contracts/HasMediaInterface.php
+
+		-
+			message: '#^Method App\\Contracts\\HasMediaInterface\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Contracts/HasMediaInterface.php
+
+		-
+			message: '#^Method App\\Contracts\\HasMediaInterface\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with no value type specified in iterable type array\|Illuminate\\Support\\Collection\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Contracts/HasMediaInterface.php
+
+		-
+			message: '#^Method App\\Contracts\\MediaInterface\:\:getAllMediaUrls\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Contracts/MediaInterface.php
+
+		-
+			message: '#^Method App\\Enums\\Builder\\BuilderContext\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Enums/Builder/BuilderContext.php
+
+		-
+			message: '#^Method App\\Enums\\EmailStatus\:\:getValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Enums/EmailStatus.php
+
+		-
+			message: '#^Method App\\Enums\\InboundEmailHook\:\:getValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Enums/InboundEmailHook.php
+
+		-
+			message: '#^Method App\\Enums\\NotificationType\:\:getValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Enums/NotificationType.php
+
+		-
+			message: '#^Method App\\Enums\\ReceiverType\:\:getValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Enums/ReceiverType.php
+
+		-
+			message: '#^Method App\\Enums\\TemplateType\:\:getValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Enums/TemplateType.php
+
+		-
+			message: '#^Method App\\Helpers\\EmailStyleHelper\:\:buildBorderStyles\(\) has parameter \$border with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Helpers/EmailStyleHelper.php
+
+		-
+			message: '#^Method App\\Helpers\\EmailStyleHelper\:\:buildLayoutStyles\(\) has parameter \$layoutStyles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Helpers/EmailStyleHelper.php
+
+		-
+			message: '#^Method App\\Helpers\\EmailStyleHelper\:\:buildTextStyles\(\) has parameter \$layoutStyles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Helpers/EmailStyleHelper.php
+
+		-
+			message: '#^Method App\\Helpers\\EmailStyleHelper\:\:buildTextStyles\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Helpers/EmailStyleHelper.php
+
+		-
+			message: '#^Method App\\Helpers\\EmailStyleHelper\:\:wrapInEmailTable\(\) has parameter \$layoutStyles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Helpers/EmailStyleHelper.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Api\\ApiController\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Api/ApiController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Api\\ApiController\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Api/ApiController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Api\\ApiController\:\:validationErrorResponse\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Api/ApiController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Api\\PostController\:\:index\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Api/PostController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Auth\\LoginController\:\:credentials\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Auth/LoginController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Auth\\RegisterController\:\:create\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Auth\\RegisterController\:\:validator\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ActionLogController\:\:index\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/ActionLogController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\AiCommandController\:\:sendSSE\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Backend/AiCommandController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\AiCommandController\:\:sseHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Backend/AiCommandController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\Auth\\ScreenshotGeneratorLoginController\:\:login\(\) has parameter \$email with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Backend/Auth/ScreenshotGeneratorLoginController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\DashboardController\:\:index\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/DashboardController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\EditorController\:\:upload\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/EditorController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\LocaleController\:\:switch\(\) has parameter \$lang with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Backend/LocaleController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\MediaController\:\:api\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/MediaController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\MediaController\:\:bulkDelete\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/MediaController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\MediaController\:\:destroy\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/MediaController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\MediaController\:\:destroy\(\) has parameter \$id with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Backend/MediaController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\MediaController\:\:getUploadLimits\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/MediaController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\MediaController\:\:index\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/MediaController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\MediaController\:\:store\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/MediaController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ModuleController\:\:destroy\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/ModuleController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ModuleController\:\:index\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/ModuleController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ModuleController\:\:show\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/ModuleController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ModuleController\:\:upload\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/ModuleController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\PostController\:\:getTaxonomiesWithTerms\(\) has parameter \$postTypeModel with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Backend/PostController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\PostController\:\:getTaxonomiesWithTerms\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Backend/PostController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\PostController\:\:handleBuilderTaxonomies\(\) has parameter \$postTypeModel with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Backend/PostController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\PostController\:\:handlePostMeta\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/PostController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\PostController\:\:handleTaxonomies\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/PostController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\SendTestEmailController\:\:sendMailMessageToRecipient\(\) has parameter \$variables with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Backend/SendTestEmailController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\SettingController\:\:index\(\) has parameter \$tab with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Backend/SettingController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\SettingController\:\:store\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/SettingController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\TermController\:\:bulkDelete\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/TermController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\TermController\:\:destroy\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/TermController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\TermController\:\:edit\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/TermController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\TermController\:\:index\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/TermController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\TermController\:\:store\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/TermController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\TermController\:\:update\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/TermController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ThemeController\:\:activate\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/ThemeController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ThemeController\:\:getColorPresets\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Backend/ThemeController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ThemeController\:\:getInstalledThemes\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Http/Controllers/Backend/ThemeController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ThemeController\:\:index\(\) has parameter \$tab with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Backend/ThemeController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Backend\\ThemeController\:\:store\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Controllers/Backend/ThemeController.php
+
+		-
+			message: '#^Property App\\Http\\Controllers\\Backend\\TranslationController\:\:\$languages type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Backend/TranslationController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:canBeModified\(\) has parameter \$additionalPermission with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:checkAuthorization\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:getUserId\(\) has parameter \$user with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:preventSuperAdminModification\(\) has parameter \$additionalPermission with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:renderViewWithBreadcrumbs\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:renderViewWithBreadcrumbs\(\) has parameter \$view with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:setBreadcrumbAction\(\) has parameter \$action with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:setBreadcrumbItems\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Controller\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Property App\\Http\\Controllers\\Controller\:\:\$breadcrumbs type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Controller.php
+
+		-
+			message: '#^Property App\\Http\\Kernel\:\:\$middleware type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Kernel.php
+
+		-
+			message: '#^Property App\\Http\\Kernel\:\:\$middlewareGroups type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Kernel.php
+
+		-
+			message: '#^Property App\\Http\\Kernel\:\:\$routeMiddleware type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Kernel.php
+
+		-
+			message: '#^Property App\\Http\\Middleware\\CheckForMaintenanceMode\:\:\$except type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/CheckForMaintenanceMode.php
+
+		-
+			message: '#^Property App\\Http\\Middleware\\CheckInstallation\:\:\$excludedExtensions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/CheckInstallation.php
+
+		-
+			message: '#^Property App\\Http\\Middleware\\CheckInstallation\:\:\$excludedRoutes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/CheckInstallation.php
+
+		-
+			message: '#^Property App\\Http\\Middleware\\EncryptCookies\:\:\$except type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/EncryptCookies.php
+
+		-
+			message: '#^Method App\\Http\\Middleware\\ModuleTranslationMiddleware\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Middleware/ModuleTranslationMiddleware.php
+
+		-
+			message: '#^Method App\\Http\\Middleware\\ModuleTranslationMiddleware\:\:handle\(\) has parameter \$request with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Middleware/ModuleTranslationMiddleware.php
+
+		-
+			message: '#^Property App\\Http\\Middleware\\TrimStrings\:\:\$except type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/TrimStrings.php
+
+		-
+			message: '#^Method App\\Http\\Middleware\\TrustHosts\:\:hosts\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/TrustHosts.php
+
+		-
+			message: '#^Property App\\Http\\Middleware\\TrustProxies\:\:\$proxies type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/TrustProxies.php
+
+		-
+			message: '#^Property App\\Http\\Middleware\\VerifyCsrfToken\:\:\$except type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Middleware/VerifyCsrfToken.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\Backend\\MediaBulkDeleteRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/Backend/MediaBulkDeleteRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\Backend\\MediaUploadRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/Backend/MediaUploadRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\Common\\BulkDeleteRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/Common/BulkDeleteRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\EmailConnection\\StoreEmailConnectionRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/EmailConnection/StoreEmailConnectionRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\EmailConnection\\UpdateEmailConnectionRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/EmailConnection/UpdateEmailConnectionRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\EmailTemplateRequest\:\:authorize\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Requests/EmailTemplateRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\EmailTemplateRequest\:\:rules\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Requests/EmailTemplateRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\FormRequest\:\:canBeModified\(\) has parameter \$additionalPermission with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Requests/FormRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\FormRequest\:\:checkAuthorization\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/FormRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\FormRequest\:\:getUserId\(\) has parameter \$user with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Requests/FormRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\FormRequest\:\:preventSuperAdminModification\(\) has parameter \$additionalPermission with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/FormRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\InboundEmailConnection\\StoreInboundEmailConnectionRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/InboundEmailConnection/StoreInboundEmailConnectionRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\InboundEmailConnection\\UpdateInboundEmailConnectionRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/InboundEmailConnection/UpdateInboundEmailConnectionRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\NotificationRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/NotificationRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\Post\\StorePostRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/Post/StorePostRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\Post\\UpdatePostRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/Post/UpdatePostRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\SendTestEmailRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/SendTestEmailRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\Term\\StoreTermRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/Term/StoreTermRequest.php
+
+		-
+			message: '#^Method App\\Http\\Requests\\Term\\UpdateTermRequest\:\:rules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Requests/Term/UpdateTermRequest.php
+
+		-
+			message: '#^Method App\\Livewire\\Admin\\Menus\\Builder\:\:getTargetOptions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Method App\\Livewire\\Admin\\Menus\\Builder\:\:handleReorder\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Method App\\Livewire\\Admin\\Menus\\Builder\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Method App\\Livewire\\Admin\\Menus\\Builder\:\:reorderItems\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Property App\\Livewire\\Admin\\Menus\\Builder\:\:\$categories type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Property App\\Livewire\\Admin\\Menus\\Builder\:\:\$nestedItems with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Property App\\Livewire\\Admin\\Menus\\Builder\:\:\$pages type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Property App\\Livewire\\Admin\\Menus\\Builder\:\:\$posts type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Property App\\Livewire\\Admin\\Menus\\Builder\:\:\$routes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Property App\\Livewire\\Admin\\Menus\\Builder\:\:\$rules has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Property App\\Livewire\\Admin\\Menus\\Builder\:\:\$tags type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Admin/Menus/Builder.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\BasePostsListing\:\:getPostsProperty\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Components/BasePostsListing.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\BasePostsListing\:\:\$categories type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Components/BasePostsListing.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CacheManager\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/CacheManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CompactFileUploader\:\:mount\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CompactFileUploader\:\:mount\(\) has parameter \$fieldname with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CompactFileUploader\:\:mount\(\) has parameter \$model with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CompactFileUploader\:\:mount\(\) has parameter \$path with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CompactFileUploader\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CompactFileUploader\:\:updatedFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CompactFileUploader\:\:upload\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\CompactFileUploader\:\:\$fieldname has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\CompactFileUploader\:\:\$file has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\CompactFileUploader\:\:\$loading has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\CompactFileUploader\:\:\$model has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\CompactFileUploader\:\:\$path has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/CompactFileUploader.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\CoreUpgradeNotification\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/CoreUpgradeNotification.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\EmailVerificationBanner\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/EmailVerificationBanner.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:clearTempFiles\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:deleteFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:deleteFile\(\) has parameter \$fileId with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:getTempFiles\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:loadFiles\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has parameter \$attachmentModelClass with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has parameter \$fieldname with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has parameter \$foreignKey with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has parameter \$isCreateMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has parameter \$isDeletable with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has parameter \$model with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:mount\(\) has parameter \$path with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:updatedFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\FileManager\:\:upload\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$attachmentModelClass has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$fieldname has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$file has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$files has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$foreignKey has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$isCreateMode has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$isDeletable has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$isReadOnly has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$loading has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$model has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$path has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\FileManager\:\:\$tempFiles has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Components/FileManager.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\ProfileEmailVerification\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/ProfileEmailVerification.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\StatusChangeButton\:\:castValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\StatusChangeButton\:\:castValue\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\StatusChangeButton\:\:changeStatusTo\(\) has parameter \$newStatus with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\StatusChangeButton\:\:determineFieldType\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\StatusChangeButton\:\:mount\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\StatusChangeButton\:\:mount\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Method App\\Livewire\\Components\\StatusChangeButton\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Property App\\Livewire\\Components\\StatusChangeButton\:\:\$options type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Components/StatusChangeButton.php
+
+		-
+			message: '#^Method App\\Livewire\\Dashboard\\QuickDraft\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Dashboard/QuickDraft.php
+
+		-
+			message: '#^Method App\\Livewire\\Dashboard\\RecentPosts\:\:getPostsProperty\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Dashboard/RecentPosts.php
+
+		-
+			message: '#^Method App\\Livewire\\Dashboard\\RecentPosts\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Dashboard/RecentPosts.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ActionLogDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ActionLogDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ActionLogDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ActionLogDatatable\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ActionLogDatatable\:\:updatingType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\ActionLogDatatable\:\:\$disabledRoutes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\ActionLogDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to static method Spatie\\QueryBuilder\\QueryBuilder\<Illuminate\\Database\\Eloquent\\Model\>\:\:for\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Livewire/Datatable/ActionLogDatatable.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(App\\Livewire\\Datatable\\Datatable\) and ''getDeleteAction'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:buildQueryWithAutoSearch\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:deleteItem\(\) has parameter \$id with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:generateHeaderForColumn\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:generateRelationshipHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getActionCellPermissions\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getActionCellPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getActionsColumnHeader\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getAllowedColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getBulkDeleteAction\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getData\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\CursorPaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getData\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\Paginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getDeleteAction\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getDeleteRouteUrl\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getEditRouteUrl\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getFilterPropertyNames\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getItemRouteParameters\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getItemRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getModelHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getPaginatedData\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getPaginatedData\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getPerPageOptions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getRouteUrl\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getRoutes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getTableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:getViewRouteUrl\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:handleBulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderActionsColumn\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderAfterActionDelete\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderAfterActionEdit\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderAfterActionView\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderBeforeActionView\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderCreatedAtColumn\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderIdCell\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderTimestampColumn\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:renderUpdatedAtColumn\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:shouldIncludeColumn\(\) has parameter \$allowedColumns with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:showActionItems\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:sortBy\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:sortQuery\(\) has parameter \$query with generic class Spatie\\QueryBuilder\\QueryBuilder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:sortQuery\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:sortQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:updatingPerPage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\Datatable\:\:updatingSearch\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$customFilters has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$disabledRoutes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$excludedColumns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$filters type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$headers type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$perPageOptions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$permissions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$relationships type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$searchableColumns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\Datatable\:\:\$selectedItems type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to static method Spatie\\QueryBuilder\\QueryBuilder\<Illuminate\\Database\\Eloquent\\Model\>\:\:for\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Livewire/Datatable/Datatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getActionCellPermissions\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getActionCellPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getItemRouteParameters\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getItemRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:getRoutes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:handleBulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:renderAfterActionEdit\(\) has parameter \$connection with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:renderAfterActionView\(\) has parameter \$connection with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:renderBeforeActionView\(\) has parameter \$connection with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\EmailConnectionDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getActionCellPermissions\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getActionCellPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getItemRouteParameters\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getItemRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:getRoutes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:handleBulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:renderAfterActionEdit\(\) has parameter \$emailTemplate with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:renderAfterActionView\(\) has parameter \$emailTemplate with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:updatingType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\EmailTemplateDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/EmailTemplateDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getActionCellPermissions\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getActionCellPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getItemRouteParameters\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getItemRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:getRoutes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:handleBulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:renderAfterActionView\(\) has parameter \$connection with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:renderBeforeActionView\(\) has parameter \$connection with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\InboundEmailConnectionDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/InboundEmailConnectionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:deleteItem\(\) has parameter \$id with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:getActionCellPermissions\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:getActionCellPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:getData\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:getDeleteAction\(\) has parameter \$id with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:getDeleteAction\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\ModuleDatatable\:\:renderActionsColumn\(\) has parameter \$module with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\ModuleDatatable\:\:\$disabledRoutes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\ModuleDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/ModuleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getActionCellPermissions\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getActionCellPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getItemRouteParameters\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getItemRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:getRoutes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:handleBulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:renderAfterActionView\(\) has parameter \$notification with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:updatingNotificationType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\NotificationDatatable\:\:updatingReceiverType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\NotificationDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/NotificationDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PermissionDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/PermissionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PermissionDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PermissionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PermissionDatatable\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PermissionDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\PermissionDatatable\:\:\$disabledRoutes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PermissionDatatable.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to static method Spatie\\QueryBuilder\\QueryBuilder\<Illuminate\\Database\\Eloquent\\Model\>\:\:for\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Livewire/Datatable/PermissionDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:getItemRouteParameters\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:getItemRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:getRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:updatingCategory\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:updatingStatus\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\PostDatatable\:\:updatingTag\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\PostDatatable\:\:\$categories type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\PostDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to static method Spatie\\QueryBuilder\\QueryBuilder\<Illuminate\\Database\\Eloquent\\Model\>\:\:for\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Livewire/Datatable/PostDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\RoleDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/RoleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\RoleDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/RoleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\RoleDatatable\:\:handleBulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/RoleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\RoleDatatable\:\:sortQuery\(\) has parameter \$query with generic class Spatie\\QueryBuilder\\QueryBuilder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/RoleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\RoleDatatable\:\:sortQuery\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/RoleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\RoleDatatable\:\:sortQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/RoleDatatable.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to static method Spatie\\QueryBuilder\\QueryBuilder\<Illuminate\\Database\\Eloquent\\Model\>\:\:for\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Livewire/Datatable/RoleDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\TermDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\TermDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\TermDatatable\:\:getItemRouteParameters\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\TermDatatable\:\:getItemRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\TermDatatable\:\:getRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\TermDatatable\:\:renderNameColumn\(\) has parameter \$term with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\TermDatatable\:\:renderParentColumn\(\) has parameter \$term with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\TermDatatable\:\:\$disabledRoutes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to static method Spatie\\QueryBuilder\\QueryBuilder\<Illuminate\\Database\\Eloquent\\Model\>\:\:for\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Livewire/Datatable/TermDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:buildQuery\(\) return type with generic class Spatie\\QueryBuilder\\QueryBuilder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:getActionCellPermissions\(\) has parameter \$item with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:getActionCellPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:getFilters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:handleBulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:renderAfterActionDelete\(\) has parameter \$user with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:renderAfterActionEdit\(\) has parameter \$user with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Datatable\\UserDatatable\:\:updatingRole\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Property App\\Livewire\\Datatable\\UserDatatable\:\:\$queryString type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to static method Spatie\\QueryBuilder\\QueryBuilder\<Illuminate\\Database\\Eloquent\\Model\>\:\:for\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Livewire/Datatable/UserDatatable.php
+
+		-
+			message: '#^Method App\\Livewire\\Install\\InstallWizard\:\:getDrivers\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Install/InstallWizard.php
+
+		-
+			message: '#^Method App\\Livewire\\Install\\InstallWizard\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Install/InstallWizard.php
+
+		-
+			message: '#^Property App\\Livewire\\Install\\InstallWizard\:\:\$availableModules type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Install/InstallWizard.php
+
+		-
+			message: '#^Property App\\Livewire\\Install\\InstallWizard\:\:\$moduleInstallResults type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Install/InstallWizard.php
+
+		-
+			message: '#^Property App\\Livewire\\Install\\InstallWizard\:\:\$persistentProperties type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Install/InstallWizard.php
+
+		-
+			message: '#^Property App\\Livewire\\Install\\InstallWizard\:\:\$requirements type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Install/InstallWizard.php
+
+		-
+			message: '#^Property App\\Livewire\\Install\\InstallWizard\:\:\$selectedModules type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Install/InstallWizard.php
+
+		-
+			message: '#^Method App\\Livewire\\Marketplace\\MarketplaceModuleBrowser\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Marketplace/MarketplaceModuleBrowser.php
+
+		-
+			message: '#^Property App\\Livewire\\Marketplace\\MarketplaceModuleBrowser\:\:\$queryString has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Livewire/Marketplace/MarketplaceModuleBrowser.php
+
+		-
+			message: '#^Method App\\Livewire\\Pages\\BaseFrontendPage\:\:renderWithLayout\(\) has parameter \$seoParams with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Pages/BaseFrontendPage.php
+
+		-
+			message: '#^Method App\\Livewire\\Pages\\BaseFrontendPage\:\:renderWithLayout\(\) has parameter \$viewData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Pages/BaseFrontendPage.php
+
+		-
+			message: '#^Method App\\Livewire\\Pages\\BasePostsArchive\:\:getPostsProperty\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Pages/BasePostsArchive.php
+
+		-
+			message: '#^Property App\\Livewire\\Pages\\BasePostsArchive\:\:\$categories type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Pages/BasePostsArchive.php
+
+		-
+			message: '#^Method App\\Livewire\\Pages\\BaseSearchPage\:\:getResultsProperty\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Pages/BaseSearchPage.php
+
+		-
+			message: '#^Property App\\Livewire\\Pages\\BaseSinglePost\:\:\$relatedPosts type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Pages/BaseSinglePost.php
+
+		-
+			message: '#^Property App\\Livewire\\Pages\\BaseSinglePost\:\:\$relatedPosts type has no value type specified in iterable type array\|Illuminate\\Support\\Collection\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Livewire/Pages/BaseSinglePost.php
+
+		-
+			message: '#^Property App\\Livewire\\Pages\\BaseSinglePost\:\:\$relatedPosts with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Pages/BaseSinglePost.php
+
+		-
+			message: '#^Method App\\Livewire\\Pages\\BaseTaxonomyArchive\:\:getPostsProperty\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Livewire/Pages/BaseTaxonomyArchive.php
+
+		-
+			message: '#^Method App\\Models\\ActionLog\:\:getActionTypes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/ActionLog.php
+
+		-
+			message: '#^Class App\\Models\\AiCommandLog has PHPDoc tag @property for property \$intent with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/AiCommandLog.php
+
+		-
+			message: '#^Class App\\Models\\AiCommandLog has PHPDoc tag @property for property \$plan with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/AiCommandLog.php
+
+		-
+			message: '#^Class App\\Models\\AiCommandLog has PHPDoc tag @property for property \$result with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/AiCommandLog.php
+
+		-
+			message: '#^Class App\\Models\\AiCommandLog uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/AiCommandLog.php
+
+		-
+			message: '#^Class App\\Models\\EmailConnection uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:creator\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeActive\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeActive\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeByProvider\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeByProvider\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeDefault\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeDefault\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeOrdered\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopeOrdered\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\EmailConnection\:\:updater\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/EmailConnection.php
+
+		-
+			message: '#^Class App\\Models\\EmailLog uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeBounced\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeBounced\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeByStatus\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeByStatus\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeClicked\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeClicked\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeDelivered\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeDelivered\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeFailed\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeFailed\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeOpened\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeOpened\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeSent\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:scopeSent\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:sender\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Method App\\Models\\EmailLog\:\:template\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/EmailLog.php
+
+		-
+			message: '#^Class App\\Models\\EmailSubscription uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailSubscription.php
+
+		-
+			message: '#^Method App\\Models\\EmailSubscription\:\:scopeSubscribed\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailSubscription.php
+
+		-
+			message: '#^Method App\\Models\\EmailSubscription\:\:scopeSubscribed\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailSubscription.php
+
+		-
+			message: '#^Method App\\Models\\EmailSubscription\:\:scopeUnsubscribed\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailSubscription.php
+
+		-
+			message: '#^Method App\\Models\\EmailSubscription\:\:scopeUnsubscribed\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailSubscription.php
+
+		-
+			message: '#^Class App\\Models\\EmailTemplate uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:creator\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:emailLogs\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:renderTemplate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeActive\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeActive\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeByType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeByType\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopeByType\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Method App\\Models\\EmailTemplate\:\:updater\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/EmailTemplate.php
+
+		-
+			message: '#^Class App\\Models\\InboundEmail uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:connection\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:getReferencesArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:handlerModel\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\MorphTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeByHandler\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeByHandler\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeFailed\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeFailed\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeFromEmail\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeFromEmail\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopePending\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopePending\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeProcessed\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmail\:\:scopeProcessed\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/InboundEmail.php
+
+		-
+			message: '#^Class App\\Models\\InboundEmailConnection uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:creator\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:emailConnection\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:inboundEmails\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopeActive\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopeActive\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopeDueForPolling\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopeDueForPolling\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Method App\\Models\\InboundEmailConnection\:\:updater\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/InboundEmailConnection.php
+
+		-
+			message: '#^Class App\\Models\\Menu uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:buildTree\(\) has parameter \$items with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:buildTree\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:getAvailableLocations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:getNestedItems\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:items\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:rootItems\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopeActive\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopeActive\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Method App\\Models\\Menu\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/Menu.php
+
+		-
+			message: '#^Class App\\Models\\MenuItem uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:children\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:descendants\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:getAvailableTypes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:getChildren\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:menu\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:parent\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopeActive\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopeActive\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopeRoots\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Method App\\Models\\MenuItem\:\:scopeRoots\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/MenuItem.php
+
+		-
+			message: '#^Class App\\Models\\Module has PHPDoc tag @property for property \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Module.php
+
+		-
+			message: '#^Class App\\Models\\Module implements generic interface ArrayAccess but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Module.php
+
+		-
+			message: '#^Class App\\Models\\Module implements generic interface Illuminate\\Contracts\\Support\\Arrayable but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Module.php
+
+		-
+			message: '#^Method App\\Models\\Module\:\:__construct\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Module.php
+
+		-
+			message: '#^Property App\\Models\\Module\:\:\$tags type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Module.php
+
+		-
+			message: '#^Class App\\Models\\Notification uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:creator\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:emailTemplate\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:getNotificationTypeIcon\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:getNotificationTypeLabel\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeActive\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeActive\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeByReceiverType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeByReceiverType\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeByType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeByType\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopeByType\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\Notification\:\:updater\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/Notification.php
+
+		-
+			message: '#^Method App\\Models\\NotificationType\:\:getValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/NotificationType.php
+
+		-
+			message: '#^Method App\\Models\\NotificationType\:\:icon\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/NotificationType.php
+
+		-
+			message: '#^Method App\\Models\\NotificationType\:\:label\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/NotificationType.php
+
+		-
+			message: '#^Method App\\Models\\Permission\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^Method App\\Models\\Permission\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^Method App\\Models\\Permission\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^Method App\\Models\\Permission\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^Method App\\Models\\Permission\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^Method App\\Models\\Permission\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^Method App\\Models\\Permission\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/Permission.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(App\\Models\\Post\) and ''getExcludedSortColu…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Class App\\Models\\Post uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:author\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:categories\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:children\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with no value type specified in iterable type array\|Illuminate\\Support\\Collection\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:getAllMediaUrls\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:getAllMeta\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:getAllMetaValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:getExcludedSortColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:getGalleryImages\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:getPostStatuses\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:parent\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:postMeta\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeFilterByCategory\(\) has parameter \$categoryId with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeFilterByCategory\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeFilterByTag\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeFilterByTag\(\) has parameter \$tagId with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopePublished\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:scopeType\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:tags\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:terms\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany does not specify its types\: TRelatedModel, TDeclaringModel, TPivotModel, TAccessor \(2\-4 required\)$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Method App\\Models\\Post\:\:user\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/Post.php
+
+		-
+			message: '#^Class App\\Models\\PostMeta uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PostMeta.php
+
+		-
+			message: '#^Method App\\Models\\PostMeta\:\:post\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/PostMeta.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(App\\Models\\Role\) and ''getExcludedSortColu…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:getExcludedSortColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Method App\\Models\\Role\:\:sortByPermissionsCount\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/Role.php
+
+		-
+			message: '#^Class App\\Models\\Setting uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Setting.php
+
+		-
+			message: '#^Class App\\Models\\SocialAccount uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/SocialAccount.php
+
+		-
+			message: '#^Method App\\Models\\SocialAccount\:\:user\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/SocialAccount.php
+
+		-
+			message: '#^Class App\\Models\\Taxonomy uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Taxonomy.php
+
+		-
+			message: '#^Method App\\Models\\Taxonomy\:\:terms\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Taxonomy.php
+
+		-
+			message: '#^Class App\\Models\\Term uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:children\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:clearMediaCollectionExcept\(\) has parameter \$excludedMedia with no value type specified in iterable type array\|Illuminate\\Support\\Collection\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:generateSlugFromString\(\) has parameter \$model with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:getAllMediaUrls\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:parent\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:posts\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany does not specify its types\: TRelatedModel, TDeclaringModel, TPivotModel, TAccessor \(2\-4 required\)$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:setSlugAttribute\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:sortByPostCount\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:sortByPostsCount\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Method App\\Models\\Term\:\:taxonomyModel\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/Term.php
+
+		-
+			message: '#^Class App\\Models\\User uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:actionLogs\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:avatar\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:canBeModified\(\) has parameter \$additionalPermission with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:checkAuthorization\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:getCasts\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:getSearchableColumns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:getUserId\(\) has parameter \$user with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:hasAnyPermission\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:preventSuperAdminModification\(\) has parameter \$additionalPermission with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:scopeApplyFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:scopeApplyFilters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:scopeApplyFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:scopePaginateData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:scopePaginateData\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:scopePaginateData\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:socialAccounts\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:userMeta\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^PHPDoc tag @return with type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator is not subtype of native type Illuminate\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Property App\\Models\\User\:\:\$casts type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Property App\\Models\\User\:\:\$fillable type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Property App\\Models\\User\:\:\$hidden type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\UserMeta\:\:user\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\BelongsTo does not specify its types\: TRelatedModel, TDeclaringModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Models/UserMeta.php
+
+		-
+			message: '#^Method App\\Notifications\\AdminResetPasswordNotification\:\:buildCustomEmail\(\) has parameter \$notifiable with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Notifications/AdminResetPasswordNotification.php
+
+		-
+			message: '#^Method App\\Notifications\\AdminResetPasswordNotification\:\:buildCustomEmail\(\) has parameter \$notification with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Notifications/AdminResetPasswordNotification.php
+
+		-
+			message: '#^Method App\\Notifications\\AdminResetPasswordNotification\:\:buildCustomEmail\(\) has parameter \$url with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Notifications/AdminResetPasswordNotification.php
+
+		-
+			message: '#^Method App\\Observers\\MediaObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/MediaObserver.php
+
+		-
+			message: '#^Method App\\Observers\\MediaObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/MediaObserver.php
+
+		-
+			message: '#^Method App\\Observers\\PostMetaObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/PostMetaObserver.php
+
+		-
+			message: '#^Method App\\Observers\\PostMetaObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/PostMetaObserver.php
+
+		-
+			message: '#^Method App\\Observers\\PostObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/PostObserver.php
+
+		-
+			message: '#^Method App\\Observers\\PostObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/PostObserver.php
+
+		-
+			message: '#^Method App\\Observers\\RoleObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/RoleObserver.php
+
+		-
+			message: '#^Method App\\Observers\\RoleObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/RoleObserver.php
+
+		-
+			message: '#^Method App\\Observers\\SettingObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/SettingObserver.php
+
+		-
+			message: '#^Method App\\Observers\\SettingObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/SettingObserver.php
+
+		-
+			message: '#^Method App\\Observers\\TermObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/TermObserver.php
+
+		-
+			message: '#^Method App\\Observers\\TermObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/TermObserver.php
+
+		-
+			message: '#^Method App\\Observers\\UserMetaObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/UserMetaObserver.php
+
+		-
+			message: '#^Method App\\Observers\\UserMetaObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/UserMetaObserver.php
+
+		-
+			message: '#^Method App\\Observers\\UserObserver\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/UserObserver.php
+
+		-
+			message: '#^Method App\\Observers\\UserObserver\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Observers/UserObserver.php
+
+		-
+			message: '#^Method App\\Policies\\BasePolicy\:\:canBeModifiedInDemoMode\(\) has parameter \$resource with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Policies/BasePolicy.php
+
+		-
+			message: '#^Method App\\Policies\\BasePolicy\:\:userOwnsResource\(\) has parameter \$resource with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Policies/BasePolicy.php
+
+		-
+			message: '#^Method App\\Providers\\ContentServiceProvider\:\:tablesExist\(\) has parameter \$tables with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Providers/ContentServiceProvider.php
+
+		-
+			message: '#^Property App\\Providers\\EventServiceProvider\:\:\$listen type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Providers/EventServiceProvider.php
+
+		-
+			message: '#^Method App\\Services\\ActionLogService\:\:getPaginatedActionLogs\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ActionLogService.php
+
+		-
+			message: '#^Method App\\Services\\ActionLogService\:\:getPaginatedActionLogs\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/ActionLogService.php
+
+		-
+			message: '#^Method App\\Services\\AiContentGeneratorService\:\:extractGeminiContent\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/AiContentGeneratorService.php
+
+		-
+			message: '#^Method App\\Services\\AiContentGeneratorService\:\:generateContent\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/AiContentGeneratorService.php
+
+		-
+			message: '#^Method App\\Services\\AiContentGeneratorService\:\:getAvailableProviders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/AiContentGeneratorService.php
+
+		-
+			message: '#^Method App\\Services\\AiContentGeneratorService\:\:parseResponse\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/AiContentGeneratorService.php
+
+		-
+			message: '#^Method App\\Services\\BackupService\:\:getBackups\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BackupService.php
+
+		-
+			message: '#^Method App\\Services\\BackupService\:\:getCurrentVersion\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BackupService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:bulkDelete\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:bulkUpdate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:bulkUpdate\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:create\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:getAll\(\) has parameter \$with with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:getAll\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:getPaginated\(\) has parameter \$with with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:getPaginated\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseService\:\:update\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseService.php
+
+		-
+			message: '#^Method App\\Services\\BaseTypeRegistry\:\:getMeta\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseTypeRegistry.php
+
+		-
+			message: '#^Method App\\Services\\BaseTypeRegistry\:\:register\(\) has parameter \$meta with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseTypeRegistry.php
+
+		-
+			message: '#^Property App\\Services\\BaseTypeRegistry\:\:\$allMeta type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/BaseTypeRegistry.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockMigrator\:\:getBlocksNeedingMigration\(\) has parameter \$blocks with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockMigrator\:\:getBlocksNeedingMigration\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockMigrator\:\:migrateBlock\(\) has parameter \$block with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockMigrator\:\:migrateBlock\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockMigrator\:\:migrateBlocks\(\) has parameter \$blocks with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockMigrator\:\:migrateBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockMigrator\:\:needsMigration\(\) has parameter \$block with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\BlockMigrator\:\:\$currentVersions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\BlockMigrator\:\:\$migrationCache type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockMigrator.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRegistryService\:\:all\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRegistryService\:\:get\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRegistryService\:\:getByCategory\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRegistryService\:\:getForContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRegistryService\:\:getJavaScriptData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRegistryService\:\:register\(\) has parameter \$definition with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRegistryService\:\:validateDefinition\(\) has parameter \$definition with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^PHPDoc tag @var for variable \$filteredBlocks has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\BlockRegistryService\:\:\$blocks type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRegistryService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRenderer\:\:extractProps\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockRenderer\:\:renderBlock\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRenderer.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\BlockRenderer\:\:\$discoveredCallbacks type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:button\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:columns\(\) has parameter \$children with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:columns\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:countdown\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:createTemplateData\(\) has parameter \$blocks with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:createTemplateData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:defaultLayoutStyles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:divider\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:featureBox\(\) has parameter \$layoutStyles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:featureBox\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:footer\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:generateEmailHtml\(\) has parameter \$blocks with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:generateEmailHtml\(\) has parameter \$canvasSettings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:generatePageHtml\(\) has parameter \$blocks with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:generatePageHtml\(\) has parameter \$canvasSettings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:getDefaultCanvasSettings\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:getDefaultPageCanvasSettings\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:heading\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:icon\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:image\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:listBlock\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:listBlock\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:parseBlocks\(\) has parameter \$blocks with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:quote\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderBlock\(\) has parameter \$block with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderButton\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderCountdown\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderDivider\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderFooter\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderHeading\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderImage\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderList\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderQuote\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderSocial\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderSpacer\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderTable\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderText\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:renderVideo\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:section\(\) has parameter \$children with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:section\(\) has parameter \$padding with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:section\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:social\(\) has parameter \$links with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:social\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:spacer\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:statsItem\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:table\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:table\(\) has parameter \$rows with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:table\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:text\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BlockService\:\:video\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BlockService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:getBlockRenderCallbacks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:getConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:getFeaturesForContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:getLabelsForContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:getModuleScripts\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:getModuleScriptsForBlade\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:registerBlock\(\) has parameter \$definition with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\BuilderService\:\:renderBlock\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^PHPDoc tag @var for variable \$filteredConfig has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\BuilderService\:\:\$blockRenderCallbacks type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\BuilderService\:\:\$moduleScripts type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/BuilderService.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:buildCanvasWrapperStyle\(\) has parameter \$canvasSettings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:buildMargin\(\) has parameter \$margin with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:buildPadding\(\) has parameter \$padding with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:render\(\) has parameter \$blocks with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:render\(\) has parameter \$canvasSettings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderBlock\(\) has parameter \$block with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderButton\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderColumns\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderDivider\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderFeatureBox\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderHeading\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderIcon\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderImage\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderSection\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderSpacer\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderStatsItem\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:renderText\(\) has parameter \$props with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\Builder\\DesignJsonRenderer\:\:wrapWithLayoutStyles\(\) has parameter \$layoutStyles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\DesignJsonRenderer\:\:\$discoveredCallbacks type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\DesignJsonRenderer\:\:\$discoveredStyles type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\DesignJsonRenderer\:\:\$gradientDirectionMap type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Property App\\Services\\Builder\\DesignJsonRenderer\:\:\$renderedBlockTypes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Builder/DesignJsonRenderer.php
+
+		-
+			message: '#^Method App\\Services\\CacheService\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CacheService.php
+
+		-
+			message: '#^Method App\\Services\\CacheService\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CacheService.php
+
+		-
+			message: '#^Method App\\Services\\Charts\\ChartService\:\:generateLabels\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Charts/ChartService.php
+
+		-
+			message: '#^Method App\\Services\\Charts\\ChartService\:\:getDateRange\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Charts/ChartService.php
+
+		-
+			message: '#^Method App\\Services\\Charts\\PostChartService\:\:getDateRangeFromPeriod\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Charts/PostChartService.php
+
+		-
+			message: '#^Method App\\Services\\Charts\\PostChartService\:\:getPostActivityData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Charts/PostChartService.php
+
+		-
+			message: '#^Method App\\Services\\Charts\\UserChartService\:\:fetchUserGrowthData\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Charts/UserChartService.php
+
+		-
+			message: '#^Method App\\Services\\Charts\\UserChartService\:\:getUserHistoryData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Charts/UserChartService.php
+
+		-
+			message: '#^Method App\\Services\\Content\\ContentService\:\:addTaxonomyToPostTypes\(\) has parameter \$postTypeNames with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Content/ContentService.php
+
+		-
+			message: '#^Method App\\Services\\Content\\ContentService\:\:getPostTypes\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Content/ContentService.php
+
+		-
+			message: '#^Method App\\Services\\Content\\ContentService\:\:getTaxonomies\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/Content/ContentService.php
+
+		-
+			message: '#^Method App\\Services\\Content\\ContentService\:\:registerPostType\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Content/ContentService.php
+
+		-
+			message: '#^Method App\\Services\\Content\\ContentService\:\:registerTaxonomy\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Content/ContentService.php
+
+		-
+			message: '#^Method App\\Services\\Content\\ContentService\:\:registerTaxonomy\(\) has parameter \$postTypes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Content/ContentService.php
+
+		-
+			message: '#^Method App\\Services\\Content\\PostType\:\:__construct\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Content/PostType.php
+
+		-
+			message: '#^Method App\\Services\\Content\\PostType\:\:setAttributes\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Content/PostType.php
+
+		-
+			message: '#^Method App\\Services\\Content\\PostType\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Content/PostType.php
+
+		-
+			message: '#^Property App\\Services\\Content\\PostType\:\:\$taxonomies type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Content/PostType.php
+
+		-
+			message: '#^Method App\\Services\\CoreUpgradeService\:\:checkForUpdates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CoreUpgradeService.php
+
+		-
+			message: '#^Method App\\Services\\CoreUpgradeService\:\:getBackups\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CoreUpgradeService.php
+
+		-
+			message: '#^Method App\\Services\\CoreUpgradeService\:\:getCurrentVersion\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CoreUpgradeService.php
+
+		-
+			message: '#^Method App\\Services\\CoreUpgradeService\:\:getStoredUpdateInfo\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CoreUpgradeService.php
+
+		-
+			message: '#^Method App\\Services\\CoreUpgradeService\:\:performUpgrade\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CoreUpgradeService.php
+
+		-
+			message: '#^Method App\\Services\\CoreUpgradeService\:\:performUpgradeFromUpload\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CoreUpgradeService.php
+
+		-
+			message: '#^Method App\\Services\\CoreUpgradeService\:\:storeUpdateInfo\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CoreUpgradeService.php
+
+		-
+			message: '#^Method App\\Services\\CountryService\:\:getCountries\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/CountryService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:create\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:getActiveConnections\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:mergeCredentials\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:mergeCredentials\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:prepareData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:prepareData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:reorderPriorities\(\) has parameter \$orderedIds with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:testConnection\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailConnectionService\:\:update\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailConnectionService.php
+
+		-
+			message: '#^Property App\\Services\\EmailParserService\:\:\$quotePatterns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailParserService.php
+
+		-
+			message: '#^Property App\\Services\\EmailParserService\:\:\$signaturePatterns type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailParserService.php
+
+		-
+			message: '#^Method App\\Services\\EmailProviders\\PhpMailProvider\:\:getFormFields\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailProviders/PhpMailProvider.php
+
+		-
+			message: '#^Method App\\Services\\EmailProviders\\PhpMailProvider\:\:getTransportConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailProviders/PhpMailProvider.php
+
+		-
+			message: '#^Method App\\Services\\EmailProviders\\PhpMailProvider\:\:getValidationRules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailProviders/PhpMailProvider.php
+
+		-
+			message: '#^Method App\\Services\\EmailProviders\\SmtpProvider\:\:getFormFields\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailProviders/SmtpProvider.php
+
+		-
+			message: '#^Method App\\Services\\EmailProviders\\SmtpProvider\:\:getTransportConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailProviders/SmtpProvider.php
+
+		-
+			message: '#^Method App\\Services\\EmailProviders\\SmtpProvider\:\:getValidationRules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailProviders/SmtpProvider.php
+
+		-
+			message: '#^Method App\\Services\\EmailSubscriptionService\:\:getStats\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailSubscriptionService.php
+
+		-
+			message: '#^Method App\\Services\\EmailSubscriptionService\:\:processUnsubscribe\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EmailSubscriptionService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailSender\:\:getMailMessage\(\) has parameter \$from with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailSender.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailSender\:\:getMailMessage\(\) has parameter \$recipientEmail with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailSender.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailSender\:\:getMailMessage\(\) has parameter \$userId with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailSender.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailSender\:\:getMailMessage\(\) has parameter \$userType with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailSender.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailSender\:\:getMailMessage\(\) has parameter \$variables with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailSender.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:_buildTemplateQuery\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:_buildTemplateQuery\(\) has parameter \$filter with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:createTemplate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:getAllTemplates\(\) has parameter \$filter with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:getAllTemplates\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:getAllTemplatesExcept\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:getEmailTemplatesDropdown\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:getPaginatedTemplates\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:getTemplatesByType\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:getTemplatesByType\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailTemplateService\:\:updateTemplate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailTemplateService.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailVariable\:\:getAllVariablesData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailVariable.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailVariable\:\:getAvailableVariables\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailVariable.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailVariable\:\:getPreviewSampleData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailVariable.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailVariable\:\:getReplacementData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailVariable.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\EmailVariable\:\:replaceVariables\(\) has parameter \$variables with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/EmailVariable.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\Mailer\:\:send\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/Mailer.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\Mailer\:\:send\(\) has parameter \$view with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/Mailer.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\VariableRegistry\:\:all\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/VariableRegistry.php
+
+		-
+			message: '#^Method App\\Services\\Emails\\VariableRegistry\:\:register\(\) has parameter \$meta with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Emails/VariableRegistry.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:batchWriteKeysToEnvFile\(\) has parameter \$keys with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:get\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:get\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:getAvailableKeys\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:maybeWriteKeysToEnvFile\(\) has parameter \$keys with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:write\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\EnvWriter\:\:write\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/EnvWriter.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forBlogListing\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forCustom\(\) has parameter \$extra with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forCustom\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forHomepage\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forPage\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forPost\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forSearch\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:forTerm\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:mergeDefaults\(\) has parameter \$params with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\Frontend\\SeoHelper\:\:mergeDefaults\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Frontend/SeoHelper.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:adjacentPosts\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:applyCategoryFilter\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:applyCategoryFilter\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:applySearchFilter\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:applySearchFilter\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:applySort\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:applySort\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:getCategories\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:paginatePosts\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:paginatePosts\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:postsForTerm\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:publishedPostsQuery\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:relatedPosts\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\FrontendQueryService\:\:searchPosts\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/FrontendQueryService.php
+
+		-
+			message: '#^Method App\\Services\\IconService\:\:getBootstrapIcons\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/IconService.php
+
+		-
+			message: '#^Method App\\Services\\IconService\:\:getIcons\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/IconService.php
+
+		-
+			message: '#^Method App\\Services\\ImageService\:\:deleteImageFromPublic\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/ImageService.php
+
+		-
+			message: '#^Method App\\Services\\ImageService\:\:storeImageAndGetUrl\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/ImageService.php
+
+		-
+			message: '#^Method App\\Services\\ImapService\:\:createInboundEmail\(\) has parameter \$emailData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ImapService.php
+
+		-
+			message: '#^Method App\\Services\\ImapService\:\:fetchEmailDetails\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ImapService.php
+
+		-
+			message: '#^Method App\\Services\\ImapService\:\:fetchRecentEmails\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ImapService.php
+
+		-
+			message: '#^Method App\\Services\\ImapService\:\:fetchUnreadEmails\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ImapService.php
+
+		-
+			message: '#^Method App\\Services\\ImapService\:\:parseBody\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ImapService.php
+
+		-
+			message: '#^Method App\\Services\\ImapService\:\:parsePart\(\) has parameter \$result with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ImapService.php
+
+		-
+			message: '#^Method App\\Services\\InboundEmailProcessor\:\:createInboundEmail\(\) has parameter \$emailData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InboundEmailProcessor.php
+
+		-
+			message: '#^Method App\\Services\\InboundEmailProcessor\:\:filterAlreadyImportedEmails\(\) has parameter \$emails with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InboundEmailProcessor.php
+
+		-
+			message: '#^Method App\\Services\\InboundEmailProcessor\:\:filterAlreadyImportedEmails\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InboundEmailProcessor.php
+
+		-
+			message: '#^Method App\\Services\\InboundEmailProcessor\:\:processAllDueConnections\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InboundEmailProcessor.php
+
+		-
+			message: '#^Method App\\Services\\InboundEmailProcessor\:\:processConnection\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InboundEmailProcessor.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:buildDsn\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:checkDirectories\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:checkExtensions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:checkPhpVersion\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:checkRequirements\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:createAdminUser\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:fetchMarketplaceModules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:getAvailableDrivers\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:getLocalModules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:runMigrateCommand\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:runMigrations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:saveSiteSettings\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:testDatabaseConnection\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:testDatabaseConnection\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\InstallationService\:\:writeDatabaseConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Property App\\Services\\InstallationService\:\:\$requiredExtensions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Property App\\Services\\InstallationService\:\:\$writableDirectories type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/InstallationService.php
+
+		-
+			message: '#^Method App\\Services\\LanguageService\:\:getActiveLanguages\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/LanguageService.php
+
+		-
+			message: '#^Method App\\Services\\LanguageService\:\:getLanguageNames\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/LanguageService.php
+
+		-
+			message: '#^Method App\\Services\\LanguageService\:\:getLanguages\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/LanguageService.php
+
+		-
+			message: '#^Property App\\Services\\LanguageService\:\:\$languageNames type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/LanguageService.php
+
+		-
+			message: '#^Method App\\Services\\LicenseVerificationService\:\:getAllStoredLicenses\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/LicenseVerificationService.php
+
+		-
+			message: '#^Method App\\Services\\LicenseVerificationService\:\:getStoredLicense\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/LicenseVerificationService.php
+
+		-
+			message: '#^Method App\\Services\\MediaLibraryService\:\:bulkDeleteMedia\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MediaLibraryService.php
+
+		-
+			message: '#^Method App\\Services\\MediaLibraryService\:\:getMediaList\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MediaLibraryService.php
+
+		-
+			message: '#^Method App\\Services\\MediaLibraryService\:\:getMediaStatistics\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MediaLibraryService.php
+
+		-
+			message: '#^Method App\\Services\\MediaLibraryService\:\:uploadMedia\(\) has parameter \$files with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MediaLibraryService.php
+
+		-
+			message: '#^Method App\\Services\\MediaLibraryService\:\:uploadMedia\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MediaLibraryService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:createMenu\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:createMenuItem\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:exportMenu\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:exportMenuItems\(\) has parameter \$items with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:exportMenuItems\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:getAvailableCategories\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:getAvailablePages\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:getAvailablePosts\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:getAvailableRoutes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:getAvailableTags\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:getNestedItemsForLocation\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:importMenuItems\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:updateItemsOrder\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:updateMenu\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\:\:updateMenuItem\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuItem\:\:setAttributes\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuItem.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuItem\:\:setChildren\(\) has parameter \$children with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuItem.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuItem\:\:setPermissions\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuItem.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuItem\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuItem.php
+
+		-
+			message: '#^Property App\\Services\\MenuService\\AdminMenuItem\:\:\$permissions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuItem.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuService\:\:addMenuItem\(\) has parameter \$item with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuService\:\:applyFiltersToMenuItems\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuService\:\:createAdminMenuItem\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuService\:\:getMenu\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/MenuService/AdminMenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuService\:\:isCurrentTermBelongsToPostType\(\) has parameter \$taxonomies with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuService.php
+
+		-
+			message: '#^Method App\\Services\\MenuService\\AdminMenuService\:\:render\(\) has parameter \$groupItems with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/MenuService/AdminMenuService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\MarketplaceService\:\:callModulesApi\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 2
+			path: app/Services/Modules/MarketplaceService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\MarketplaceService\:\:extractFolderName\(\) has parameter \$moduleJson with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/MarketplaceService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\MarketplaceService\:\:fetchModules\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 2
+			path: app/Services/Modules/MarketplaceService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\MarketplaceService\:\:fetchModulesFromDatabase\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 2
+			path: app/Services/Modules/MarketplaceService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\MarketplaceService\:\:installFromExtracted\(\) has parameter \$moduleInfo with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/MarketplaceService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:extractAuthor\(\) has parameter \$moduleJson with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:getModuleAssetPath\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:getModuleStatuses\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:getPaginatedModules\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:getRawModuleStatuses\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:moduleViteCompile\(\) has parameter \$manifestFile with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:saveModuleStatuses\(\) has parameter \$statuses with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:toggleModule\(\) has parameter \$enable with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleService\:\:toggleModule\(\) has parameter \$moduleName with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/Modules/ModuleService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:buildUpdateCheckPayload\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:cacheResult\(\) has parameter \$result with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:callUpdateApi\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:callUpdateApi\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:checkForUpdates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:checkUpdatesFromDatabase\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:checkUpdatesFromDatabase\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\Modules\\ModuleUpdateService\:\:getCachedUpdates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/Modules/ModuleUpdateService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:_buildNotificationQuery\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:_buildNotificationQuery\(\) has parameter \$filter with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:createNotification\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:getAllNotifications\(\) has parameter \$filter with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:getAllNotifications\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:getNotificationsByReceiverType\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:getNotificationsByType\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:getNotificationsByType\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:getPaginatedNotifications\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\NotificationService\:\:updateNotification\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/NotificationService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:createPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getAllPermissionModels\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getAllPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getAllPermissionsWithFilters\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getDatabasePermissionGroups\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getPaginatedPermissionsWithRoleCount\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getPermissionGroups\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getPermissionModelsByGroup\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getPermissionsByGroup\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getPermissionsByNames\(\) has parameter \$permissionNames with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getPermissionsByNames\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:getRolesForPermission\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:removePermissions\(\) has parameter \$permissionNames with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:syncPermissionsForRoles\(\) has parameter \$permissionGroups with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:syncPermissionsForRoles\(\) has parameter \$roleNames with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PermissionService\:\:syncPermissionsForRoles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PermissionService.php
+
+		-
+			message: '#^Method App\\Services\\PostMetaService\:\:deleteMultipleMeta\(\) has parameter \$keys with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostMetaService.php
+
+		-
+			message: '#^Method App\\Services\\PostMetaService\:\:getAllMeta\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PostMetaService.php
+
+		-
+			message: '#^Method App\\Services\\PostMetaService\:\:getAllMetaAsArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostMetaService.php
+
+		-
+			message: '#^Method App\\Services\\PostMetaService\:\:getAllMetaValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostMetaService.php
+
+		-
+			message: '#^Method App\\Services\\PostMetaService\:\:syncMeta\(\) has parameter \$metaData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostMetaService.php
+
+		-
+			message: '#^Method App\\Services\\PostMetaService\:\:updateMultipleMeta\(\) has parameter \$metaData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostMetaService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:bulkDeletePosts\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:createPost\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:getPaginatedPosts\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:getPaginatedPosts\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:getPostTerms\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:getPosts\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:getPosts\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\PostService\:\:updatePost\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/PostService.php
+
+		-
+			message: '#^Method App\\Services\\RecaptchaService\:\:getAvailablePages\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RecaptchaService.php
+
+		-
+			message: '#^Property App\\Services\\RecaptchaService\:\:\$enabledPages type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RecaptchaService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:create\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:createPredefinedRoles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:createRole\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:getAllRoles\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:getPaginatedRoles\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:getPaginatedRolesWithUserCount\(\) return type with generic interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:getPermissionsByGroup\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:getPermissionsByGroupName\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:getPredefinedRolePermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:getRolesDropdown\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:roleHasPermissions\(\) has parameter \$permissions with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:update\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\RolesService\:\:updateRole\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/RolesService.php
+
+		-
+			message: '#^Method App\\Services\\SettingService\:\:getAllSettings\(\) has parameter \$autoload with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/SettingService.php
+
+		-
+			message: '#^Method App\\Services\\SettingService\:\:getAllSettings\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/SettingService.php
+
+		-
+			message: '#^Method App\\Services\\SettingService\:\:getSettings\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/SettingService.php
+
+		-
+			message: '#^Property App\\Services\\SettingService\:\:\$excluded_settings type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/SettingService.php
+
+		-
+			message: '#^Method App\\Services\\SlugService\:\:generateSlugFromString\(\) has parameter \$model with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/SlugService.php
+
+		-
+			message: '#^Method App\\Services\\SlugService\:\:setSlugAttribute\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/SlugService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:canDeleteTerm\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:createTerm\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:getPaginatedTerms\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:getPaginatedTerms\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:getTaxonomy\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:getTerms\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:getTerms\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:getTermsDropdown\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\TermService\:\:updateTerm\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TermService.php
+
+		-
+			message: '#^Method App\\Services\\ThemeColorService\:\:generateColorPalette\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/ThemeColorService.php
+
+		-
+			message: '#^Method App\\Services\\TimezoneService\:\:getTimezones\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TimezoneService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:arrayMergeRecursiveDistinct\(\) has parameter \$array1 with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:arrayMergeRecursiveDistinct\(\) has parameter \$array2 with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:arrayMergeRecursiveDistinct\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:calculateTranslationStats\(\) has parameter \$enTranslations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:calculateTranslationStats\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:calculateTranslationStats\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:countNonEmptyTranslations\(\) has parameter \$enArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:countNonEmptyTranslations\(\) has parameter \$translationArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:countTotalKeys\(\) has parameter \$array with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:countTranslationsRecursively\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:createEmptyTranslations\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:createEmptyTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:createGroupTranslationFile\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:findDifferentTranslations\(\) has parameter \$core with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:findDifferentTranslations\(\) has parameter \$submitted with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:findDifferentTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:findDifferentTranslationsRecursive\(\) has parameter \$core with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:findDifferentTranslationsRecursive\(\) has parameter \$submitted with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:findDifferentTranslationsRecursive\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:flattenTranslations\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:flattenTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getAvailableTranslationGroups\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getCoreGroupTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getCoreJsonTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getDefaultTranslationsForGroup\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getGroupTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getGroups\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getJsonTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getUserGroupTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:getUserJsonTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:saveGroupTranslations\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:saveJsonTranslations\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:saveTranslations\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:unflattenTranslations\(\) has parameter \$translations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:unflattenTranslations\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\TranslationService\:\:varExport\(\) has parameter \$expression with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Property App\\Services\\TranslationService\:\:\$groups type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/TranslationService.php
+
+		-
+			message: '#^Method App\\Services\\UnsubscribeService\:\:process\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Services/UnsubscribeService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:applyFilters\(\) has parameter \$request with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:assignUserRoles\(\) has parameter \$roles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:bulkCreateMetadata\(\) has parameter \$metadataRecords with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:bulkDeleteUsers\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:bulkUpdateMetadata\(\) has parameter \$metadataRecords with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:createUser\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:createUserWithMetadata\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:createUserWithMetadata\(\) has parameter \$request with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:createUserWithRelations\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:getMetadataFieldValueForUpdate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:getMetadataFieldValueForUpdate\(\) has parameter \$request with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:getUserDropdownList\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:getUserMetadataFieldGroups\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:getUsers\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:getUsers\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:handleUserMetadata\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:handleUserMetadata\(\) has parameter \$request with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:handleUserRoles\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:pluck\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:prepareMetadataRecord\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:prepareMetadataRecord\(\) has parameter \$request with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:prepareMetadataRecord\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:prepareUserData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:prepareUserData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:prepareUserDataWithAvatar\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:prepareUserDataWithAvatar\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:shouldProcessMetadataField\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:shouldUpdatePassword\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:syncUserRoles\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:updateUser\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:updateUserAttributes\(\) has parameter \$userData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:updateUserRoles\(\) has parameter \$roles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:updateUserWithMetadata\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:updateUserWithMetadata\(\) has parameter \$request with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Method App\\Services\\UserService\:\:updateUserWithRelations\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/UserService.php
+
+		-
+			message: '#^Class App\\Support\\Facades\\Mailer has PHPDoc tag @method for method getConnectionInfo\(\) return type with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Facades/Mailer.php
+
+		-
+			message: '#^Class App\\Support\\Facades\\Mailer has PHPDoc tag @method for method send\(\) parameter \#1 \$view with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Facades/Mailer.php
+
+		-
+			message: '#^Class App\\Support\\Facades\\Mailer has PHPDoc tag @method for method send\(\) parameter \#2 \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Facades/Mailer.php
+
+		-
+			message: '#^Class App\\Support\\Facades\\Theme has PHPDoc tag @method for method registerDefaults\(\) parameter \#1 \$defaults with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Facades/Theme.php
+
+		-
+			message: '#^Method App\\Support\\Helper\\MediaHelper\:\:checkPhpUploadError\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/MediaHelper.php
+
+		-
+			message: '#^Method App\\Support\\Helper\\MediaHelper\:\:getAllowedMimeTypesForDemo\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/MediaHelper.php
+
+		-
+			message: '#^Method App\\Support\\Helper\\MediaHelper\:\:getUploadLimits\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/MediaHelper.php
+
+		-
+			message: '#^Function add_menu_item\(\) has parameter \$item with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function generate_unique_slug\(\) has parameter \$model with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function get_languages\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function get_module_asset_paths\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function get_settings\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function invoke_setting\(\) has parameter \$parameters with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function module_vite_compile\(\) has parameter \$manifestFile with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function store_image_url\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/common.php
+
+		-
+			message: '#^Function get_permalink\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_post\(\) has parameter \$id with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_post_terms\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_post_type\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_post_types\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_posts\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_posts\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_taxonomies\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_term\(\) has parameter \$id with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_terms\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function get_terms\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function register_post_type\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function register_post_type\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function register_taxonomy\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function register_taxonomy\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function register_taxonomy\(\) has parameter \$postTypes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/content.php
+
+		-
+			message: '#^Function ld_add_action\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_add_action\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_add_action\(\) has parameter \$callback with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_add_action\(\) has parameter \$priority with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_add_filter\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_add_filter\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_add_filter\(\) has parameter \$callback with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_add_filter\(\) has parameter \$priority with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_apply_filters\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_apply_filters\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_apply_filters\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Function ld_do_action\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Helper/hooks.php
+
+		-
+			message: '#^Method App\\Support\\Modules\\CustomFileRepository\:\:getModulePath\(\) has parameter \$module with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Support/Modules/CustomFileRepository.php
+
+		-
+			message: '#^Method App\\Support\\ThemeManager\:\:registerDefaults\(\) has parameter \$defaults with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Support/ThemeManager.php
+
+		-
+			message: '#^Method App\\View\\Components\\Menu\:\:filterByDepth\(\) has parameter \$items with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/View/Components/Menu.php
+
+		-
+			message: '#^Method App\\View\\Components\\Menu\:\:filterByDepth\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/View/Components/Menu.php
+
+		-
+			message: '#^Property App\\View\\Components\\Menu\:\:\$items with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/View/Components/Menu.php
+
+		-
+			message: '#^Method App\\View\\Components\\TermDrawer\:\:__construct\(\) has parameter \$taxonomy with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/View/Components/TermDrawer.php
+
+		-
+			message: '#^Method App\\View\\Components\\TermDrawer\:\:__construct\(\) has parameter \$taxonomyName with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/View/Components/TermDrawer.php
+
+		-
+			message: '#^Class Database\\Factories\\SettingFactory extends generic class Illuminate\\Database\\Eloquent\\Factories\\Factory but does not specify its types\: TModel$#'
+			identifier: missingType.generics
+			count: 1
+			path: database/factories/SettingFactory.php
+
+		-
+			message: '#^Method Database\\Factories\\SettingFactory\:\:mailFromAddress\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: database/factories/SettingFactory.php
+
+		-
+			message: '#^Method Database\\Factories\\SettingFactory\:\:mailFromAddress\(\) has parameter \$address with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: database/factories/SettingFactory.php
+
+		-
+			message: '#^Method Database\\Factories\\SettingFactory\:\:mailFromAddress\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: database/factories/SettingFactory.php
+
+		-
+			message: '#^Method Database\\Factories\\SettingFactory\:\:mailFromName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: database/factories/SettingFactory.php
+
+		-
+			message: '#^Method Database\\Factories\\SettingFactory\:\:mailFromName\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: database/factories/SettingFactory.php
+
+		-
+			message: '#^Method Illuminate\\Database\\Migrations\\Migration@anonymous/database/migrations/2025_01_15_000001_create_email_templates_table\.php\:14\:\:getEmailVerificationBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/migrations/2025_01_15_000001_create_email_templates_table.php
+
+		-
+			message: '#^Method Illuminate\\Database\\Migrations\\Migration@anonymous/database/migrations/2025_01_15_000001_create_email_templates_table\.php\:14\:\:getForgotPasswordBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/migrations/2025_01_15_000001_create_email_templates_table.php
+
+		-
+			message: '#^Method Illuminate\\Database\\Migrations\\Migration@anonymous/database/migrations/2025_01_15_000001_create_email_templates_table\.php\:14\:\:getRegistrationWelcomeBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/migrations/2025_01_15_000001_create_email_templates_table.php
+
+		-
+			message: '#^Method Illuminate\\Database\\Migrations\\Migration@anonymous/database/migrations/2026_04_03_000001_create_account_created_notification\.php\:14\:\:getAccountCreatedBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/migrations/2026_04_03_000001_create_account_created_notification.php
+
+		-
+			message: '#^Method Database\\Seeders\\AboutPageSeeder\:\:getAboutPageBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/AboutPageSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\ContentSeeder\:\:logAction\(\) has parameter \$additionalData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/ContentSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\ContentSeeder\:\:storeActionLog\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/ContentSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getAllTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getAuthTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getBackInStockBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getBirthdayDiscountBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getBlackFridayBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getBlogRoundupBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getBoldWelcomeBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getCartAbandonmentBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getCompanyNewsletterBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getConferenceInviteBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getCyberMondayBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getEcommerceTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getEventReminderBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getEventTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getEventThankYouBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getFlashSaleBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getIndustryNewsBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getInvoiceBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getLimitedOfferBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getMarketingTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getMinimalistWelcomeBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getModernWelcomeBlueBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getNewsletterTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getOrderConfirmationBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getPasswordResetBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getProductLaunchBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getProductRecommendationBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getReceiptBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getReviewRequestBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getShippingNotificationBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getTipsNewsletterBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getTransactionalTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getVirtualEventBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getWebinarInvitationBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getWeeklyDigestBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getWelcomeChecklistBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getWelcomeTemplates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php
+
+		-
+			message: '#^Method Database\\Seeders\\EmailTemplateSeeder\:\:getWelcomeWithVideoBlocks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: database/seeders/EmailTemplateSeeder.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,8 @@ parameters:
         - database
         - routes
 
-    # Level 5 is a good starting point
-    level: 5
+    # Level 6+ required per Pesantech Engineering Playbook §9.1
+    level: 6
     
     # Turn off strict checking for PHPDoc types
     treatPhpDocTypesAsCertain: false

--- a/resources/js/components/charts/user-growth-chart.js
+++ b/resources/js/components/charts/user-growth-chart.js
@@ -1,3 +1,4 @@
+/* global userGrowthData, userGrowthLabels */
 import ApexCharts from "apexcharts";
 
 const userGrowthData_Data = typeof userGrowthData !== 'undefined' ? userGrowthData : [];


### PR DESCRIPTION
…ngineering Playbook v1.1

Quality gates:
- phpstan.neon: bump level 5 → 6 (§9.1)
- ci.yml: MySQL 8.0 → 8.4, add Redis service, migration rollback test, composer audit, npm audit, gitleaks secret scanning, Rector dry-run (§9.2)

Security:
- .env.example: add TELESCOPE_ENABLED=false, PULSE_ENABLED=false (§4.7)
- .env.example: add CORS_ALLOWED_ORIGINS with production warning (§11.1)
- config/cors.php: env-based allowed_origins instead of hardcoded wildcard (§11.1)

Repo metadata:
- .github/dependabot.yml: enable composer, npm, github-actions auto-updates (§3.3, §11.6)
- .github/CODEOWNERS: default reviewer @pesantechid/engineering (§3.3)
- .github/PULL_REQUEST_TEMPLATE.md: playbook-aligned checklist (§3.3, §8.3)

Documentation:
- docs/playbook.md: copy of Pesantech Engineering Playbook v1.1 (§4.5)
- docs/adr/0001-adopt-pesantech-engineering-playbook.md (§13)
- docs/adr/0002-base-version-pinned.md — records laradashboard v1.1.3 sync (§4.4, §13)

Infrastructure:
- Dockerfile.production: FrankenPHP-based production image (§4.5, §10.3)
- docker/caddy/Caddyfile: security headers, health endpoint, static asset caching
- docker/php/php-production.ini: OPcache, hardened PHP settings
- docker/entrypoint.sh: artisan optimize + migrate on startup
- docker-compose.dev.yml: mysql:8.4, redis:7, mailpit, minio for local dev (§4.5, §4.7)

Remaining manual step: enable branch protection on main via GitHub Settings (§3.2, §9.3)